### PR TITLE
Issue/100 reconnect

### DIFF
--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -205,7 +205,7 @@ const collabClient = (function(){
 
     function _attemptReconnect() {
         console.info(`Attempting to reconnect to ${_collabId}.`);
-        connect(_collabId, getDefaultName(), true);
+        connect(_collabId, getDefaultName(), false);
     }
 
     /**

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -276,7 +276,9 @@ const collabClient = (function(){
     function connect(id, name=getDefaultName(), include=false) {
         tmappUI.displayImageError("loadingcollab");
         if (_ws) {
-            swapImage(tmapp.getImageName(), id);
+            if (_ws.readyState === 1) {
+                swapImage(tmapp.getImageName(), id);
+            }
             disconnect();
         }
         _ongoingDestruction = _ongoingDestruction.then(() => {

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -28,9 +28,6 @@ const collabClient = (function(){
      * @param {string} msg.type The type of message being received.
      */
     function _handleMessage(msg) {
-        if (msg === "__pong__") {
-            return;
-        }
         switch(msg.type) {
             case "annotationAction":
                 _handleAnnotationAction(msg);
@@ -236,7 +233,7 @@ const collabClient = (function(){
 
     function _keepalive() {
         send("__ping__");
-        _keepaliveTimeout = setTimeout(_keepalive, _keepaliveTimeout);
+        _keepaliveTimeout = setTimeout(_keepalive, _keepaliveTime);
     }
 
     function _stopKeepalive() {
@@ -347,7 +344,9 @@ const collabClient = (function(){
                 }
             }
             ws.onmessage = function(event) {
-                _handleMessage(JSON.parse(event.data));
+                if (event.data !== "__pong__") {
+                    _handleMessage(JSON.parse(event.data));
+                }
             }
             ws.onclose = function(event) {
                 if (event.code === 1000) {

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -14,7 +14,7 @@ const collabClient = (function(){
         _userId;
 
     const _idleTime = 20 * 60 * 1000; // 20 minutes
-    const _keepaliveTime = 30 * 1000;
+    const _keepaliveTime = 30 * 1000; // sending ping every 30s
     let _idleTimeout, _keepaliveTimeout;
 
     let _ongoingDestruction = new Promise(r => r());
@@ -232,7 +232,7 @@ const collabClient = (function(){
     }
 
     function _keepalive() {
-        send("__ping__");
+        send("__ping__", false);
         _keepaliveTimeout = setTimeout(_keepalive, _keepaliveTime);
     }
 
@@ -391,9 +391,11 @@ const collabClient = (function(){
      * @param {Object} msg Message to be sent.
      * @param {string} msg.type Type of the message being sent.
      */
-    function send(msg) {
+    function send(msg, resetIdle=true) {
         if (_ws) {
-            _postponeIdle();
+            if (resetIdle) {
+                _postponeIdle();
+            }
             if (typeof(msg) === "object") {
                 _ws.send(JSON.stringify(msg));
             }

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -342,7 +342,7 @@ const collabClient = (function(){
                     const title = event.code === 4000 ?
                         "Connection closed due to inactivity"
                         : "Lost connection to the server";
-                    _promptReconnect(title);
+                    setTimeout(() => _promptReconnect(title), 2000);
                 }
             }
         });

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -294,8 +294,10 @@ const collabClient = (function(){
      * @param {string} name The name used to identify the participant.
      * @param {boolean} include Whether or not already-placed annotations
      * should be included in the collaborative workspace.
+     * @param {boolean} askAboutInclude Whether or not the user should be
+     * prompted about the inclusion of annotations.
      */
-    function connect(id, name=getDefaultName(), include=false) {
+    function connect(id, name=getDefaultName(), include=false, askAboutInclude=false) {
         tmappUI.displayImageError("loadingcollab");
         if (_ws) {
             if (_ws.readyState === 1) {
@@ -322,7 +324,7 @@ const collabClient = (function(){
                     _joinBatch = [];
                     _requestSummary();
                 }
-                else if (annotationHandler.isEmpty() || confirm("All your placed annotations will be lost unless you have saved them. Do you want to continue anyway?")) {
+                else if (!askAboutInclude || annotationHandler.isEmpty() || confirm("All your placed annotations will be lost unless you have saved them. Do you want to continue anyway?")) {
                     annotationHandler.clear(false);
                     _requestSummary();
                 }

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -32,8 +32,8 @@ class Collaboration {
         this.nextMemberId = 0;
         this.nextColor = generateColor();
         this.image = image;
-        this.loadState(false);
         this.ongoingLoad = new Promise(r => r()); // Dummy promise just in case
+        this.loadState(false);
         this.log(`Initializing collaboration.`, console.info);
     }
 
@@ -250,23 +250,23 @@ class Collaboration {
         }
 
         this.ongoingLoad = this.ongoingLoad.then(() => {
-            return autosave.loadAnnotations(this.id, this.image).then(data => {
-                if (data.version === "1.0") {
-                    if (data.name) {
-                        this.name = data.name;
-                    }
-                    this.annotations = data.annotations;
+            return autosave.loadAnnotations(this.id, this.image);
+        }).then(data => {
+            if (data.version === "1.0") {
+                if (data.name) {
+                    this.name = data.name;
                 }
-            }).catch(() => {
-                this.log(`Couldn't load preexisting annotations for ${this.image}.`, console.info);
-                this.annotations = [];
-            }).finally(() => {
-                const nameChangeMsg = {type: "nameChange", name: this.name};
-                this.broadcastMessage(nameChangeMsg);
-                if (forceUpdate) {
-                    this.forceUpdate();
-                }
-            });
+                this.annotations = data.annotations;
+            }
+        }).catch(() => {
+            this.log(`Couldn't load preexisting annotations for ${this.image}.`, console.info);
+            this.annotations = [];
+        }).finally(() => {
+            const nameChangeMsg = {type: "nameChange", name: this.name};
+            this.broadcastMessage(nameChangeMsg);
+            if (forceUpdate) {
+                this.forceUpdate();
+            }
         });
     }
 

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -249,22 +249,24 @@ class Collaboration {
             return;
         }
 
-        this.ongoingLoad = autosave.loadAnnotations(this.id, this.image).then(data => {
-            if (data.version === "1.0") {
-                if (data.name) {
-                    this.name = data.name;
+        this.ongoingLoad = this.ongoingLoad.then(() => {
+            return autosave.loadAnnotations(this.id, this.image).then(data => {
+                if (data.version === "1.0") {
+                    if (data.name) {
+                        this.name = data.name;
+                    }
+                    this.annotations = data.annotations;
                 }
-                this.annotations = data.annotations;
-            }
-        }).catch(() => {
-            this.log(`Couldn't load preexisting annotations for ${this.image}.`, console.info);
-            this.annotations = [];
-        }).finally(() => {
-            const nameChangeMsg = {type: "nameChange", name: this.name};
-            this.broadcastMessage(nameChangeMsg);
-            if (forceUpdate) {
-                this.forceUpdate();
-            }
+            }).catch(() => {
+                this.log(`Couldn't load preexisting annotations for ${this.image}.`, console.info);
+                this.annotations = [];
+            }).finally(() => {
+                const nameChangeMsg = {type: "nameChange", name: this.name};
+                this.broadcastMessage(nameChangeMsg);
+                if (forceUpdate) {
+                    this.forceUpdate();
+                }
+            });
         });
     }
 

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -382,6 +382,10 @@ function leaveCollab(ws, id) {
  * @param {string} msg JSON representation of the message object.
  */
 function handleMessage(ws, id, msg) {
+    if (msg === "__ping__") {
+        ws.send("__pong__");
+        return;
+    }
     const collab = getCollab(id);
     try {
         collab.handleMessage(ws, JSON.parse(msg));


### PR DESCRIPTION
User is now prompted to try to reconnect if the server is shut down during a connection, to avoid filling the logs. Users are also automatically disconnected if they are idle for too long; they can reconnect with the click of a button. The idle time is set to 20 minutes, but it can be altered with the `_idleTime` constant in `public/js/collabClient.js`.