### PR TITLE
Issue 131 repeated entries

### DIFF
--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -410,13 +410,24 @@ function handleMessage(ws, id, msg) {
 
 /**
  * Get a list of all collaborations that have previously been saved
- * for a given image.
+ * for a given image, as well as empty collaborations currently open on
+ * the server.
  * @param {string} image The name of the image.
  * @returns {Promise<Array<Object>>} A promise of the list of available
  * image ids and their names.
  */
 function getAvailable(image) {
-    return autosave.getSavedIds(image);
+    const availableInStorage = autosave.getSavedIds(image);
+    const availableRunning = collabs.map(collab => {
+        return {
+            id: collab.id,
+            name: collab.name
+        };
+    });
+    const availableNotInStorage = availableRunning.filter(collab => {
+        return !availableInStorage.some(entry => entry.id === collab.id);
+    });
+    return availableInStorage.concat(availableNotInStorage);
 }
 
 module.exports = function(dir) {

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -272,11 +272,11 @@ class Collaboration {
 
     saveState() {
         if (!this.image) {
-            return;
+            return Promise.resolve();
         }
-        else if (a.length === 0) {
+        else if (this.annotations.length === 0) {
             this.log("Tried to save session, ignored as there was no data.", console.info);
-            return;
+            return Promise.resolve();
         }
 
         const data = {

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -274,6 +274,10 @@ class Collaboration {
         if (!this.image) {
             return;
         }
+        else if (a.length === 0) {
+            this.log("Tried to save session, ignored as there was no data.", console.info);
+            return;
+        }
 
         const data = {
             version: "1.0",

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -221,10 +221,12 @@ class Collaboration {
     }
 
     handleNameChange(sender, member, msg) {
-        this.name = msg.name;
-        this.flagUnsavedChanges();
-        this.saveState();
-        this.forwardMessage(sender, msg);
+        if (this.name !== msg.name) {
+            this.name = msg.name;
+            this.flagUnsavedChanges();
+            this.saveState();
+            this.forwardMessage(sender, msg);
+        }
     }
 
     stateSummary(sender) {
@@ -303,6 +305,7 @@ class Collaboration {
 
     trySavingState() {
         if (!this.autosaveTimeout) {
+            this.saveState();
             this.autosaveTimeout = setTimeout(() => {
                 this.saveState();
                 this.autosaveTimeout = null;
@@ -412,25 +415,13 @@ function handleMessage(ws, id, msg) {
 
 /**
  * Get a list of all collaborations that have previously been saved
- * for a given image, as well as empty collaborations currently open on
- * the server.
+ * for a given image.
  * @param {string} image The name of the image.
  * @returns {Promise<Array<Object>>} A promise of the list of available
  * image ids and their names.
  */
 function getAvailable(image) {
-    return autosave.getSavedIds(image).then(availableInStorage => {
-        const availableRunning = Object.values(collabs).map(collab => {
-            return {
-                id: collab.id,
-                name: collab.name
-            };
-        });
-        const availableNotInStorage = availableRunning.filter(collab => {
-            return !availableInStorage.some(entry => entry.id === collab.id);
-        });
-        return availableInStorage.concat(availableNotInStorage);
-    });
+    return autosave.getSavedIds(image);
 }
 
 module.exports = function(dir) {

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -417,17 +417,18 @@ function handleMessage(ws, id, msg) {
  * image ids and their names.
  */
 function getAvailable(image) {
-    const availableInStorage = autosave.getSavedIds(image);
-    const availableRunning = collabs.map(collab => {
-        return {
-            id: collab.id,
-            name: collab.name
-        };
+    return autosave.getSavedIds(image).then(availableInStorage => {
+        const availableRunning = Object.values(collabs).map(collab => {
+            return {
+                id: collab.id,
+                name: collab.name
+            };
+        });
+        const availableNotInStorage = availableRunning.filter(collab => {
+            return !availableInStorage.some(entry => entry.id === collab.id);
+        });
+        return availableInStorage.concat(availableNotInStorage);
     });
-    const availableNotInStorage = availableRunning.filter(collab => {
-        return !availableInStorage.some(entry => entry.id === collab.id);
-    });
-    return availableInStorage.concat(availableNotInStorage);
 }
 
 module.exports = function(dir) {


### PR DESCRIPTION
Pull request for #131 . I had originally made it so that all sessions showed up, including those not yet on disk, but I have now changed it to be limited to those that have been saved. Also includes some small changes so that the first autosave will happen sooner when placing annotations, and so that renaming a session to its current name will not count as an unsaved change.