### PR TITLE
Issue/51 global comments

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -98,6 +98,18 @@
                             </div>
                         </div>
 
+                        <!-- Collapse for global comments -->
+                        <button type="button" class="btn btn-block btn-primary collapsed" data-toggle="collapse" data-target="#comments_collapse">
+                            <div class="d-flex flex-row w-100"><div class="w-100">Comments</div> <i class="collapse_rotate fa fa-chevron-down pull-right pt-1"></i></div>
+                        </button>
+                        <div class="m-2">
+                            <div class="collapse card" id="comments_collapse">
+                                <div class="card-body" id="global_comments">
+                                    <!-- Comments -->
+                                </div>
+                            </div>
+                        </div>
+
                         <button type="button" class="btn btn-block btn-secondary" data-toggle="modal" data-target="#instructions">
                             Usage instructions
                         </button>

--- a/public/index.html
+++ b/public/index.html
@@ -524,6 +524,7 @@
 <script src="classConfig.js"></script>
 <script src="js/utils/classUtils.js"></script>
 <script src="js/collabClient.js"></script>
+<script src="js/metadataHandler.js"></script>
 <script src="js/annotationHandler.js"></script>
 <script src="js/overlayHandler.js"></script>
 <script src="js/fileBrowserUI.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -111,7 +111,7 @@
                                 <!-- Annotation tools -->
                                 <div class="col-8">
                                     <h6 class="card-subtitle mb-2 text-muted">Annotation tool</h6>
-                                    <div class="btn-group btn-group-toggle d-flex" data-toggle="buttons" role="group">
+                                    <div class="btn-group btn-group-toggle d-flex" data-toggle="buttons" role="group" onkeydown="noArrows()">
                                         <label id="tool_marker" type="button" class="btn btn-primary">
                                             <input name="tool_selection" type="radio" autocomplete="off">
                                             Marker
@@ -129,7 +129,7 @@
                                 <!-- Focus up/down --> <!-- TODO, move elsewhere -->
                                 <div class="col-4 ml-auto">
                                     <h6 class="card-subtitle mb-2 text-muted">Change focus</h6>
-                                    <div class="btn-group d-flex" role="group">
+                                    <div class="btn-group d-flex" role="group" onkeydown="noArrows()">
                                         <button id="focus_next" type="button" class="btn btn-primary">Up</button>
                                         <button id="focus_prev" type="button" class="btn btn-primary">Down</button>
                                     </div>
@@ -141,7 +141,7 @@
                                 <!-- Annotation class buttons -->
                                 <div class="col">
                                     <h6 class="card-subtitle mb-2 text-muted">Annotation class</h6>
-                                    <div id="class_buttons" class="btn-group btn-group-toggle d-flex" data-toggle="buttons" role="group">
+                                    <div id="class_buttons" class="btn-group btn-group-toggle d-flex" data-toggle="buttons" role="group" onkeydown="noArrows()">
                                     </div>
                                 </div>
                             </div>
@@ -526,6 +526,19 @@
 <script src="js/cssHelper.js"></script>
 <script src="js/htmlHelper.js"></script>
 <script src="js/annotationTool.js"></script>
+
+<script>
+    function noArrows() {
+        switch( event.keyCode ){
+            case 37://left arrow
+            case 38://up arrow
+            case 39://right arrow
+            case 40://down arrow
+                event.preventDefault();
+                break;
+        }
+    }
+</script>
 <script>
     tmappUI.initUI();
 

--- a/public/index.html
+++ b/public/index.html
@@ -82,7 +82,7 @@
                         <button type="button" class="btn btn-block btn-primary collapsed" data-toggle="collapse" data-target="#visualization_collapse">
                             <div class="d-flex flex-row w-100"><div class="w-100">Visualization adjustments</div> <i class="collapse_rotate fa fa-chevron-down pull-right pt-1"></i></div>
                         </button>
-                        <div class="m-2">
+                        <div class="m-0 my-2">
                             <div class="collapse card" id="visualization_collapse">
                                 <div class="card-body">
                                     <h6 class="card-subtitle text-muted">Brightness</h6>
@@ -103,7 +103,7 @@
                         <button type="button" class="btn btn-block btn-primary collapsed" data-toggle="collapse" data-target="#comments_collapse">
                             <div class="d-flex flex-row w-100"><div class="w-100">Comments</div> <i class="collapse_rotate fa fa-chevron-down pull-right pt-1"></i></div>
                         </button>
-                        <div class="m-2">
+                        <div class="m-0 my-2">
                             <div class="collapse card" id="comments_collapse">
                                 <div class="card-body p-2" id="global_comments">
                                     <!-- Comments -->

--- a/public/index.html
+++ b/public/index.html
@@ -105,7 +105,7 @@
                         </button>
                         <div class="m-2">
                             <div class="collapse card" id="comments_collapse">
-                                <div class="card-body" id="global_comments">
+                                <div class="card-body p-2" id="global_comments">
                                     <!-- Comments -->
                                 </div>
                             </div>

--- a/public/js/annotationStorageConversion.js
+++ b/public/js/annotationStorageConversion.js
@@ -55,6 +55,7 @@ const annotationStorageConversion = (function() {
                         label: "Replace existing annotations with loaded ones",
                         click: () => {
                             annotationHandler.clear();
+                            metadataHandler.clear();
                             addAnnotations();
                         }
                     }

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -215,6 +215,7 @@ const collabClient = (function(){
         _localMember = null;
         _ws = null;
         _collabId  = null;
+        metadataHandler.clear();
         overlayHandler.updateMembers([]);
         tmappUI.clearCollaborators();
         tmapp.clearCollab();

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -168,6 +168,9 @@ const collabClient = (function(){
             });
             _joinBatch = null;
         }
+        msg.comments.forEach(comment => {
+            metadataHandler.handleCommentFromServer(comment);
+        });
         _members = msg.members;
         _localMember = _members.find(member => member.id === msg.requesterId);
         _userId= _localMember.id;

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -158,6 +158,7 @@ const collabClient = (function(){
                 _joinBatch.push(annotation);
             });
         }
+        metadataHandler.clear();
         annotationHandler.clear(false);
         msg.annotations.forEach(annotation => {
             annotationHandler.add(annotation, "image", false)
@@ -215,7 +216,6 @@ const collabClient = (function(){
         _localMember = null;
         _ws = null;
         _collabId  = null;
-        metadataHandler.clear();
         overlayHandler.updateMembers([]);
         tmappUI.clearCollaborators();
         tmapp.clearCollab();

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -32,6 +32,9 @@ const collabClient = (function(){
             case "annotationAction":
                 _handleAnnotationAction(msg);
                 break;
+            case "metadataAction":
+                _handleMetadataAction(msg);
+                break;
             case "memberEvent":
                 _handleMemberEvent(msg);
                 break;
@@ -71,6 +74,14 @@ const collabClient = (function(){
                 break;
             default:
                 console.warn(`Unknown annotation action type: ${msg.actionType}`);
+        }
+    }
+
+    function _handleMetadataAction(msg) {
+        switch(msg.actionType) {
+            case "addComment":
+                metadataHandler.handleCommentFromServer(msg.comment);
+                break;
         }
     }
 
@@ -469,6 +480,18 @@ const collabClient = (function(){
     }
 
     /**
+     * Add a comment to the current collaboration.
+     * @param {string} content The text content of the comment.
+     */
+    function addComment(content) {
+        send({
+            type: "metadataAction",
+            actionType: "addComment",
+            content: content
+        });
+    }
+
+    /**
      * Change the name of the local collaboration member.
      * @param {string} newName The new name to be assigned to the member.
      */
@@ -688,6 +711,7 @@ const collabClient = (function(){
         updateAnnotation: updateAnnotation,
         removeAnnotation: removeAnnotation,
         clearAnnotations: clearAnnotations,
+        addComment: addComment,
         changeUsername: changeUsername,
         getDefaultName: getDefaultName,
         changeCollabName: changeCollabName,

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -500,6 +500,10 @@ const collabClient = (function(){
         });
     }
 
+    /**
+     * Remove a comment from the current collaboration.
+     * @param {number} id The id of the comment to be removed.
+     */
     function removeComment(id) {
         send({
             type: "metadataAction",

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -82,6 +82,11 @@ const collabClient = (function(){
             case "addComment":
                 metadataHandler.handleCommentFromServer(msg.comment);
                 break;
+            case "removeComment":
+                metadataHandler.handleCommentRemovalFromServer(msg.id);
+                break;
+            default:
+                console.warn(`Unknown metadata action type: ${msg.actionType}`);
         }
     }
 
@@ -495,6 +500,14 @@ const collabClient = (function(){
         });
     }
 
+    function removeComment(id) {
+        send({
+            type: "metadataAction",
+            actionType: "removeComment",
+            id: id
+        });
+    }
+
     /**
      * Change the name of the local collaboration member.
      * @param {string} newName The new name to be assigned to the member.
@@ -716,6 +729,7 @@ const collabClient = (function(){
         removeAnnotation: removeAnnotation,
         clearAnnotations: clearAnnotations,
         addComment: addComment,
+        removeComment: removeComment,
         changeUsername: changeUsername,
         getDefaultName: getDefaultName,
         changeCollabName: changeCollabName,

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -152,17 +152,17 @@ const htmlHelper = (function() {
             textarea.val("");
             inputFun(body);
         });
-        container.keyup(e => e.stopPropagation());
+        container.keypress(e => e.stopPropagation());
         container.keydown(e => e.stopPropagation());
-        container.keypress(e => {
+        container.keyup(e => {
             e.stopPropagation()
-            if ((e.code === "Enter" || e.code === "NumpadEnter" && !e.shiftKey) {
+            if ((e.code === "Enter" || e.code === "NumpadEnter") && !e.shiftKey) {
                 submitButton.click();
             }
             else if (e.code === "Escape") {
                 $("#main_content").focus();
             }
-        );
+        });
         return container;
     }
 

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -149,15 +149,18 @@ const htmlHelper = (function() {
         submitButton.click(() => {
             const textarea = container.find("textarea");
             const body = textarea.val();
-            textarea.val("");
-            inputFun(body);
+	    if (body.length > 0) {
+                textarea.val("");
+                inputFun(body);
+            }
         });
         container.keypress(e => e.stopPropagation());
-        container.keydown(e => e.stopPropagation());
-        container.keyup(e => {
-            e.stopPropagation()
+        container.keyup(e => e.stopPropagation());
+        container.keydown(e => {
+            e.stopPropagation();
             if ((e.code === "Enter" || e.code === "NumpadEnter") && !e.shiftKey) {
-                submitButton.click();
+                e.preventDefault();
+		submitButton.click();
             }
             else if (e.code === "Escape") {
                 $("#main_content").focus();

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -98,13 +98,20 @@ const htmlHelper = (function() {
             </div>
         `);
         const list = container.find("ul");
+        let stuckToBottom = true;
+        container.scroll(() => {
+            const distToBottom = list.height() - (container.height() + container.scrollTop());
+            stuckToBottom = distToBottom < 20;
+        });
         container.updateComments = comments => {
             list.empty();
             comments.forEach(comment => {
                 const entry = _commentAlt(comment, removeFun);
                 list.append(entry);
             });
-            container.scrollTop(list.height() - container.height());
+            if (stuckToBottom) {
+                container.scrollTop(list.height() - container.height());
+            }
         };
         return container;
     }

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -238,7 +238,7 @@ const htmlHelper = (function() {
      * field of the object, which will be created if no such field
      * already exists.
      * @param {Object} updateFun The function that should be run when
-     * the comments are updated.
+     * pressing the save button in the menu.
      */
     function buildCommentSection(container, commentable, updateFun) {
         const list = _commentList(commentable, updateFun);

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -329,6 +329,7 @@ const htmlHelper = (function() {
     }
 
     return {
+        buildCommentSection: buildCommentSection,
         buildAnnotationSettingsMenu: buildAnnotationSettingsMenu,
         buildClassSelectionButtons: buildClassSelectionButtons,
         buildCollaboratorList: buildCollaboratorList,

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -104,6 +104,7 @@ const htmlHelper = (function() {
                 const entry = _commentAlt(comment, removeFun);
                 list.append(entry);
             });
+            container.scrollTop(list.height() - container.height());
         };
         return container;
     }

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -104,12 +104,13 @@ const htmlHelper = (function() {
             stuckToBottom = distToBottom < 20;
         });
         container.updateComments = comments => {
+            const shouldStickToBottom = stuckToBottom;
             list.empty();
             comments.forEach(comment => {
                 const entry = _commentAlt(comment, removeFun);
                 list.append(entry);
             });
-            if (stuckToBottom) {
+            if (shouldStickToBottom) {
                 container.scrollTop(list.height() - container.height());
             }
         };

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -55,10 +55,10 @@ const htmlHelper = (function() {
     function _commentAlt(comment, removeFun) {
         const entry = $(`
             <li class="list-group-item">
-                <p class="text-break">${comment.content}</p>
+                <p class="text-break comment_body">${comment.content}</p>
                 <div class="small d-flex justify-content-between">
                     <span class="text-muted">
-                        Added by ${comment.author}
+                        Added by <span class="comment_author"></span>
                     </span>
                     <a href="#">
                         Remove
@@ -66,6 +66,8 @@ const htmlHelper = (function() {
                 </div>
             </li>
         `);
+        entry.find(".comment_body").text(comment.content);
+        entry.find(".comment_author").text(comment.author);
         const removeBtn = entry.find("a");
         removeBtn.click(() => removeFun(comment.id));
         return entry;
@@ -74,10 +76,10 @@ const htmlHelper = (function() {
     function _comment(comment, removeFun) {
         const entry = $(`
             <li class="list-group-item">
-                <p>${comment.body}</p>
+                <p class="text-break comment_body">${comment.body}</p>
                 <div class="small d-flex justify-content-between">
                     <span class="text-muted">
-                        Added by ${comment.author}
+                        Added by <span class="comment_author"></span>
                     </span>
                     <a href="#">
                         Remove
@@ -85,6 +87,8 @@ const htmlHelper = (function() {
                 </div>
             </li>
         `);
+        entry.find(".comment_body").text(comment.body);
+        entry.find(".comment_author").text(comment.author);
         const removeBtn = entry.find("a");
         removeBtn.click(removeFun);
         return entry;

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -55,7 +55,7 @@ const htmlHelper = (function() {
     function _commentAlt(comment, removeFun) {
         const entry = $(`
             <li class="list-group-item">
-                <p>${comment.content}</p>
+                <p class="text-break">${comment.content}</p>
                 <div class="small d-flex justify-content-between">
                     <span class="text-muted">
                         Added by ${comment.author}
@@ -93,7 +93,7 @@ const htmlHelper = (function() {
     function _commentListAlt(removeFun) {
         const container = $(`
             <div class="card bg-secondary mb-2" style="height: 15vh; overflow-y: auto;">
-                <ul class="list-group list-group-flush">
+                <ul class="list-group list-group-flush position-absolute">
                 </ul>
             </div>
         `);

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -93,7 +93,7 @@ const htmlHelper = (function() {
     function _commentListAlt(removeFun) {
         const container = $(`
             <div class="card bg-secondary mb-2" style="height: 15vh; overflow-y: auto;">
-                <ul class="list-group list-group-flush position-absolute">
+                <ul class="list-group list-group-flush position-absolute w-100">
                 </ul>
             </div>
         `);
@@ -192,6 +192,18 @@ const htmlHelper = (function() {
             const body = textarea.val();
             textarea.val("");
             inputFun(body);
+        });
+        container.keypress(e => e.stopPropagation());
+        container.keyup(e => e.stopPropagation());
+        container.keydown(e => {
+            e.stopPropagation();
+            if ((e.code === "Enter" || e.code === "NumpadEnter") && !e.shiftKey) {
+                e.preventDefault();
+		submitButton.click();
+            }
+            else if (e.code === "Escape") {
+                container.parent().focus();
+            }
         });
         return container;
     }

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -52,6 +52,25 @@ const htmlHelper = (function() {
         return container;
     }
 
+    function _commentAlt(comment, removeFun) {
+        const entry = $(`
+            <li class="list-group-item">
+                <p>${comment.content}</p>
+                <div class="small d-flex justify-content-between">
+                    <span class="text-muted">
+                        Added by ${comment.author}
+                    </span>
+                    <a href="#">
+                        Remove
+                    </a>
+                </div>
+            </li>
+        `);
+        const removeBtn = entry.find("a");
+        removeBtn.click(() => removeFun(comment.id));
+        return entry;
+    }
+
     function _comment(comment, removeFun) {
         const entry = $(`
             <li class="list-group-item">
@@ -67,8 +86,26 @@ const htmlHelper = (function() {
             </li>
         `);
         const removeBtn = entry.find("a");
-        removeBtn.click(removeFun);
+        removeBtn.click(() => removeFun(comment.id));
         return entry;
+    }
+
+    function _commentListAlt(removeFun) {
+        const container = $(`
+            <div class="card bg-secondary mb-2" style="height: 15vh; overflow-y: auto;">
+                <ul class="list-group list-group-flush">
+                </ul>
+            </div>
+        `);
+        const list = container.find("ul");
+        container.updateComments = comments => {
+            list.empty();
+            comments.forEach(comment => {
+                const entry = _commentAlt(comment, removeFun);
+                list.append(entry);
+            });
+        };
+        return container;
     }
 
     function _commentList(commentable, updateFun) {
@@ -96,6 +133,24 @@ const htmlHelper = (function() {
         };
         const list = container.find("ul");
         comments.forEach(container.appendComment);
+        return container;
+    }
+
+    function _commentInputAlt(inputFun) {
+        const container = $(`
+            <div class="input-group">
+                <textarea class="form-control" rows="1" style="resize: none;"></textarea>
+                <div class="input-group-append">
+                    <button type="button" class="btn btn-primary">Add comment</button>
+                </div>
+            </div>
+        `);
+        container.find("button").click(() => {
+            const textarea = container.find("textarea");
+            const body = textarea.val();
+            textarea.val("");
+            inputFun(body);
+        });
         return container;
     }
 
@@ -255,6 +310,26 @@ const htmlHelper = (function() {
     }
 
     /**
+     * Fill a jquery selection with a comment section.
+     * @param {Object} container The selection that should contain the
+     * comment section.
+     * @param {Function} inputFun The function to which the comment text
+     * should be passed when the submit button is pressed.
+     * @param {Function} removeFun The function to which the comment id
+     * should be passed when the remove button is pressed.
+     * @returns {Function} Function that is to be called with a list of
+     * comments whenever the comments are updated.
+     */
+    function buildCommentSectionAlt(container, inputFun, removeFun) {
+        // TODO: Change the other comment section to use this
+        const list = _commentListAlt(removeFun);
+        const updateFun = list.updateComments;
+        const input = _commentInputAlt(inputFun);
+        container.append(list, input);
+        return updateFun;
+    }
+
+    /**
      * Fill a jquery selection with the nodes for editing an annotation.
      * @param {Object} container The selection that should contain the
      * annotation editing menu.
@@ -330,6 +405,7 @@ const htmlHelper = (function() {
 
     return {
         buildCommentSection: buildCommentSection,
+        buildCommentSectionAlt: buildCommentSectionAlt,
         buildAnnotationSettingsMenu: buildAnnotationSettingsMenu,
         buildClassSelectionButtons: buildClassSelectionButtons,
         buildCollaboratorList: buildCollaboratorList,

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -145,7 +145,8 @@ const htmlHelper = (function() {
                 </div>
             </div>
         `);
-        container.find("button").click(() => {
+        const submitButton = container.find("button");
+        submitButton.click(() => {
             const textarea = container.find("textarea");
             const body = textarea.val();
             textarea.val("");
@@ -153,7 +154,15 @@ const htmlHelper = (function() {
         });
         container.keyup(e => e.stopPropagation());
         container.keydown(e => e.stopPropagation());
-        container.keypress(e => e.stopPropagation()); // TODO: Esc to unfocus
+        container.keypress(e => {
+            e.stopPropagation()
+            if ((e.code === "Enter" || e.code === "NumpadEnter" && !e.shiftKey) {
+                submitButton.click();
+            }
+            else if (e.code === "Escape") {
+                $("#main_content").focus();
+            }
+        );
         return container;
     }
 

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -55,7 +55,7 @@ const htmlHelper = (function() {
     function _commentAlt(comment, removeFun) {
         const entry = $(`
             <li class="list-group-item">
-                <p class="text-break comment_body">${comment.content}</p>
+                <p class="text-break comment_body" style="white-space: pre-line"></p>
                 <div class="small d-flex justify-content-between">
                     <span class="text-muted">
                         Added by <span class="comment_author"></span>
@@ -76,7 +76,7 @@ const htmlHelper = (function() {
     function _comment(comment, removeFun) {
         const entry = $(`
             <li class="list-group-item">
-                <p class="text-break comment_body">${comment.body}</p>
+                <p class="text-break comment_body" style="white-space: pre-line"></p>
                 <div class="small d-flex justify-content-between">
                     <span class="text-muted">
                         Added by <span class="comment_author"></span>

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -187,7 +187,8 @@ const htmlHelper = (function() {
                 </div>
             </div>
         `);
-        container.find("button").click(() => {
+	 const submitButton = container.find("button");
+        submitButton.click(() => {
             const textarea = container.find("textarea");
             const body = textarea.val();
             textarea.val("");
@@ -202,7 +203,7 @@ const htmlHelper = (function() {
 		submitButton.click();
             }
             else if (e.code === "Escape") {
-                container.parent().focus();
+                container.parent().parent().focus();
             }
         });
         return container;

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -86,7 +86,7 @@ const htmlHelper = (function() {
             </li>
         `);
         const removeBtn = entry.find("a");
-        removeBtn.click(() => removeFun(comment.id));
+        removeBtn.click(removeFun);
         return entry;
     }
 
@@ -367,8 +367,17 @@ const htmlHelper = (function() {
         const id = _annotationValueRow("Id", annotation.id);
         const author = _annotationValueRow("Created by", annotation.author);
         const classes = _annotationMclassOptions(annotation, updateFun);
-        container.append(id, author, classes);
-        buildCommentSection(container, annotation, updateFun);
+        const list = _commentList(annotation, updateFun);
+        const input = _commentInput(body => {
+            const comment = {
+                author: userInfo.getName(),
+                body: body
+            };
+            list.appendComment(comment);
+            annotation.comments.push(comment);
+            updateFun();
+        });
+        container.append(id, author, classes, list, input);
     }
 
     /**

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -151,6 +151,9 @@ const htmlHelper = (function() {
             textarea.val("");
             inputFun(body);
         });
+        container.keyup(e => e.stopPropagation());
+        container.keydown(e => e.stopPropagation());
+        container.keypress(e => e.stopPropagation()); // TODO: Esc to unfocus
         return container;
     }
 

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -18,8 +18,14 @@ const metadataHandler = (function() {
         // TODO
     }
 
+    function forEachComment(f) {
+        comments.forEach(comment => f(comment));
+        // TODO
+    }
+
     return {
         sendCommentToServer: sendCommentToServer,
-        handleCommentFromServer: handleCommentFromServer
+        handleCommentFromServer: handleCommentFromServer,
+        forEachComment: forEachComment
     };
 })();

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -23,9 +23,14 @@ const metadataHandler = (function() {
         // TODO
     }
 
+    function clear() {
+        // TODO
+    }
+
     return {
         sendCommentToServer: sendCommentToServer,
         handleCommentFromServer: handleCommentFromServer,
-        forEachComment: forEachComment
+        forEachComment: forEachComment,
+        clear: clear
     };
 })();

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -1,0 +1,25 @@
+/**
+ * Namespace for handling the metadata of a slide and collaboration.
+ * @namespace metadataHandler
+ */
+const metadataHandler = (function() {
+    // TODO: Comments
+    const comments = [];
+
+    // Get a copy of the comments
+    // Update the comment list
+    // Send comments over collaboration
+    function sendCommentToServer(commentText) {
+        collabClient.addComment(commentText);
+    }
+
+    function handleCommentFromServer(comment) {
+        console.log(comment);
+        // TODO
+    }
+
+    return {
+        sendCommentToServer: sendCommentToServer,
+        handleCommentFromServer: handleCommentFromServer
+    };
+})();

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -41,6 +41,7 @@ const metadataHandler = (function() {
     return {
         sendCommentToServer: sendCommentToServer,
         handleCommentFromServer: handleCommentFromServer,
+        setCommentUpdateFun: setCommentUpdateFun,
         forEachComment: forEachComment,
         clear: clear
     };

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -3,28 +3,39 @@
  * @namespace metadataHandler
  */
 const metadataHandler = (function() {
-    // TODO: Comments
-    const comments = [];
+    const _comments = [];
+    let _updateFun = null;
 
-    // Get a copy of the comments
-    // Update the comment list
-    // Send comments over collaboration
+    function _updateCommentSection() {
+        if (!_updateFun) {
+            console.warn("Could not handle comment as there is no update function set.");
+        }
+        else {
+            _updateFun(_comments);
+        }
+    }
+
     function sendCommentToServer(commentText) {
         collabClient.addComment(commentText);
     }
 
     function handleCommentFromServer(comment) {
-        console.log(comment);
-        // TODO
+        _comments.push(comment);
+        _updateCommentSection();
+    }
+
+    function setCommentUpdateFun(updateFun) {
+        _updateFun = updateFun;
     }
 
     function forEachComment(f) {
-        comments.forEach(comment => f(comment));
+        _comments.forEach(comment => f(comment));
         // TODO
     }
 
     function clear() {
-        // TODO
+        _comments.length = 0;
+        _updateCommentSection();
     }
 
     return {

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -15,19 +15,37 @@ const metadataHandler = (function() {
         }
     }
 
+    /**
+     * Submit a comment that should be added to the global comments of
+     * the current session.
+     * @param {string} commentText The text of the comment being submitted.
+     */
     function sendCommentToServer(commentText) {
         collabClient.addComment(commentText);
     }
 
+    /**
+     * Tell the server that a comment should be deleted.
+     * @param {number} id The id of the comment to be removed.
+     */
     function sendCommentRemovalToServer(id) {
         collabClient.removeComment(id);
     }
 
+    /**
+     * Receive a comment from the server and display it in the global
+     * comment section.
+     * @param {Object} comment The new comment to be added.
+     */
     function handleCommentFromServer(comment) {
         _comments.push(comment);
         _updateCommentSection();
     }
 
+    /**
+     * Receive a comment removal instruction from the server.
+     * @param {number} id The id of the comment to be removed.
+     */
     function handleCommentRemovalFromServer(id) {
         const commentIndex = _comments.findIndex(comment =>
             comment.id === id
@@ -41,13 +59,21 @@ const metadataHandler = (function() {
         }
     }
 
+    /**
+     * Set the function that should be called with the comment list
+     * whenever the comments are updated.
+     * @param {Function} updateFun The new update function.
+     */
     function setCommentUpdateFun(updateFun) {
         _updateFun = updateFun;
     }
 
+    /**
+     * Iterate some function over copies of all global comments.
+     * @param {Function} f The function to be called on all comments.
+     */
     function forEachComment(f) {
-        _comments.forEach(comment => f(comment));
-        // TODO
+        _comments.forEach(comment => f(Object.assign({}, comment)));
     }
 
     function clear() {

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -19,9 +19,26 @@ const metadataHandler = (function() {
         collabClient.addComment(commentText);
     }
 
+    function sendCommentRemovalToServer(id) {
+        collabClient.removeComment(id);
+    }
+
     function handleCommentFromServer(comment) {
         _comments.push(comment);
         _updateCommentSection();
+    }
+
+    function handleCommentRemovalFromServer(id) {
+        const commentIndex = _comments.findIndex(comment =>
+            comment.id === id
+        );
+        if (commentIndex >= 0) {
+            _comments.splice(commentIndex, 1);
+            _updateCommentSection();
+        }
+        else {
+            throw Error("Server tried to delete a comment that doesn't exist locally.");
+        }
     }
 
     function setCommentUpdateFun(updateFun) {
@@ -40,7 +57,9 @@ const metadataHandler = (function() {
 
     return {
         sendCommentToServer: sendCommentToServer,
+        sendCommentRemovalToServer: sendCommentRemovalToServer,
         handleCommentFromServer: handleCommentFromServer,
+        handleCommentRemovalFromServer: handleCommentRemovalFromServer,
         setCommentUpdateFun: setCommentUpdateFun,
         forEachComment: forEachComment,
         clear: clear

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -671,6 +671,18 @@ const tmapp = (function() {
         _viewer.clearControls();
     }
 
+    /**
+     * Sending events to OSDs keyboard handlers
+     */
+    function keyDownHandler(event) {
+        // Only arrow keys
+        _viewer.innerTracker.keyDownHandler(event);
+    }
+    function keyHandler(event) {
+        // All other OSD keys
+        _viewer.innerTracker.keyHandler(event);
+    }
+
     return {
         init: init,
         openImage: openImage,
@@ -690,6 +702,9 @@ const tmapp = (function() {
         updateCollabStatus: updateCollabStatus,
         setCursorStatus: setCursorStatus,
         enableControls: enableControls,
-        disableControls: disableControls
+        disableControls: disableControls,
+
+        keyHandler: keyHandler,
+        keyDownHandler: keyDownHandler
     };
 })();

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -86,10 +86,12 @@ const tmappUI = (function(){
 
     function _initGlobalComments() {
         const container = $("#global_comments");
-        const commentHolder = {}; // TODO
-        htmlHelper.buildCommentSection(container, commentHolder, comment => {
-            console.log("Made a comment!", commentHolder);
-        });
+        const inputFun = metadataHandler.sendCommentToServer;
+        const removeFun = id => {
+            console.log("TODO: Delete comment with id ", id);
+        };
+        const updateFun = htmlHelper.buildCommentSectionAlt(container, inputFun, removeFun);
+        metadataHandler.setCommentUpdateFun(updateFun);
     }
 
     function _initClassSelectionButtons() {

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -84,6 +84,14 @@ const tmappUI = (function(){
         }
     }
 
+    function _initGlobalComments() {
+        const container = $("#global_comments");
+        const commentHolder = {}; // TODO
+        htmlHelper.buildCommentSection(container, commentHolder, comment => {
+            console.log("Made a comment!", commentHolder);
+        });
+    }
+
     function _initClassSelectionButtons() {
         const initialMclass = classUtils.getClassFromID(0);
         annotationTool.setMclass(initialMclass.name);

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -178,6 +178,11 @@ const tmappUI = (function(){
             }
         });
 
+        // Propagate keypress events to OSD (also when not focused)
+        $("#main_content").keypress(function(){
+            tmapp.keyHandler(event);
+        });
+
         //1,2,... for class selection
         //z,x for focus up down
         $("#main_content").keydown(function(){
@@ -226,6 +231,9 @@ const tmappUI = (function(){
             }
             if (caught) {
                 event.preventDefault(); //prevent e.g. Firefox to open search box
+            }
+            else {
+                tmapp.keyDownHandler(event); //Send events on to OSD (also if not in focus)
             }
         });
     }

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -289,6 +289,7 @@ const tmappUI = (function(){
      * and add any event handlers that are needed.
      */
     function initUI() {
+        _initGlobalComments();
         _initClassSelectionButtons();
         _initToolSelectionButtons();
         _initViewerEvents();

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -87,9 +87,7 @@ const tmappUI = (function(){
     function _initGlobalComments() {
         const container = $("#global_comments");
         const inputFun = metadataHandler.sendCommentToServer;
-        const removeFun = id => {
-            console.log("TODO: Delete comment with id ", id);
-        };
+        const removeFun = metadataHandler.sendCommentRemovalToServer;
         const updateFun = htmlHelper.buildCommentSectionAlt(container, inputFun, removeFun);
         metadataHandler.setCommentUpdateFun(updateFun);
     }

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -291,11 +291,14 @@ class Collaboration {
         this.ongoingLoad = this.ongoingLoad.then(() => {
             return autosave.loadAnnotations(this.id, this.image);
         }).then(data => {
-            if (data.version === "1.0") {
+            if (data.version === "1.0" || data.version === "1.1") {
                 if (data.name) {
                     this.name = data.name;
                 }
                 this.annotations = data.annotations;
+            }
+            if (data.version === "1.1") {
+                this.comments = data.comments;
             }
         }).catch(() => {
             this.log(`Couldn't load preexisting annotations for ${this.image}.`, console.info);
@@ -313,10 +316,11 @@ class Collaboration {
     saveState() {
         if (this.hasUnsavedChanges) {
             const data = {
-                version: "1.0",
+                version: "1.1",
                 name: this.name,
                 image: this.image,
-                annotations: this.annotations
+                annotations: this.annotations,
+                comments: this.comments
             };
             return autosave.saveAnnotations(this.id, this.image, data).then(() => {
                 this.notifyAutosave();

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -410,13 +410,24 @@ function handleMessage(ws, id, msg) {
 
 /**
  * Get a list of all collaborations that have previously been saved
- * for a given image.
+ * for a given image, as well as empty collaborations currently open on
+ * the server.
  * @param {string} image The name of the image.
  * @returns {Promise<Array<Object>>} A promise of the list of available
  * image ids and their names.
  */
 function getAvailable(image) {
-    return autosave.getSavedIds(image);
+    const availableInStorage = autosave.getSavedIds(image);
+    const availableRunning = collabs.map(collab => {
+        return {
+            id: collab.id,
+            name: collab.name
+        };
+    });
+    const availableNotInStorage = availableRunning.filter(collab => {
+        return !availableInStorage.some(entry => entry.id === collab.id);
+    });
+    return availableInStorage.concat(availableNotInStorage);
 }
 
 module.exports = function(dir) {

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -309,7 +309,7 @@ class Collaboration {
                 this.comments = data.comments;
                 if (this.comments.length > 0) {
                     const commentIds = this.comments.map(comment => comment.id);
-                    nextCommentId = Math.max(...commentIds) + 1;
+                    this.nextCommentId = Math.max(...commentIds) + 1;
                 }
             }
         }).catch(() => {

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -27,6 +27,7 @@ class Collaboration {
         const date = new Date().toISOString().split("T")[0];
         this.members = new Map();
         this.annotations = [];
+        this.comments = [];
         this.id = id;
         this.name = `Unnamed (Created on ${date})`;
         this.nextMemberId = 0;
@@ -206,6 +207,7 @@ class Collaboration {
                     time: Date.now(),
                     content: msg.content
                 };
+                this.comments.push(comment);
                 this.broadcastMessage({
                     type: "metadataAction",
                     actionType: "addComment",
@@ -263,7 +265,8 @@ class Collaboration {
             requesterId: this.members.get(sender).id,
             image: this.image,
             members: Array.from(this.members.values()),
-            annotations: this.annotations
+            annotations: this.annotations,
+            comments: this.comments
         }
     }
 
@@ -297,6 +300,7 @@ class Collaboration {
         }).catch(() => {
             this.log(`Couldn't load preexisting annotations for ${this.image}.`, console.info);
             this.annotations = [];
+            this.comments = [];
         }).finally(() => {
             const nameChangeMsg = {type: "nameChange", name: this.name};
             this.broadcastMessage(nameChangeMsg);

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -135,6 +135,10 @@ class Collaboration {
                     this.handleAnnotationAction(sender, member, msg);
                 });
                 break;
+            case "metadataAction":
+                this.ongoingLoad.then(() => {
+                    this.handleMetadataAction(sender, member, msg);
+                });
             case "memberEvent":
                 this.handleMemberEvent(sender, member, msg);
                 break;
@@ -187,6 +191,30 @@ class Collaboration {
         }
         this.flagUnsavedChanges();
         this.trySavingState();
+    }
+
+    handleMetadataAction(sender, member, msg) {
+        if (!member.ready) {
+            return;
+        }
+
+        switch (msg.actionType) {
+            case "addComment":
+                const comment = {
+                    id: 3, // TODO
+                    author: member.name,
+                    time: Date.now(),
+                    content: msg.content
+                };
+                this.broadcastMessage({
+                    type: "metadataAction",
+                    actionType: "addComment",
+                    comment: comment
+                }, null, true);
+                break;
+        }
+        this.flagUnsavedChanges();
+        this.trySavingState()
     }
 
     handleMemberEvent(sender, member, msg) {

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -203,6 +203,9 @@ class Collaboration {
 
         switch (msg.actionType) {
             case "addComment":
+                if (msg.content.length === 0) {
+                    return;
+                }
                 const comment = {
                     id: this.nextCommentId++,
                     author: member.name,

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -272,11 +272,11 @@ class Collaboration {
 
     saveState() {
         if (!this.image) {
-            return;
+            return Promise.resolve();
         }
-        else if (a.length === 0) {
+        else if (this.annotations.length === 0) {
             this.log("Tried to save session, ignored as there was no data.", console.info);
-            return;
+            return Promise.resolve();
         }
 
         const data = {

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -203,14 +203,15 @@ class Collaboration {
 
         switch (msg.actionType) {
             case "addComment":
-                if (msg.content.length === 0) {
+                const cleanContent = msg.content.trim();
+                if (cleanContent.length === 0) {
                     return;
                 }
                 const comment = {
                     id: this.nextCommentId++,
                     author: member.name,
                     time: Date.now(),
-                    content: msg.content
+                    content: cleanContent
                 };
                 this.comments.push(comment);
                 this.broadcastMessage({

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -274,6 +274,10 @@ class Collaboration {
         if (!this.image) {
             return;
         }
+        else if (a.length === 0) {
+            this.log("Tried to save session, ignored as there was no data.", console.info);
+            return;
+        }
 
         const data = {
             version: "1.0",

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -141,6 +141,7 @@ class Collaboration {
                 this.ongoingLoad.then(() => {
                     this.handleMetadataAction(sender, member, msg);
                 });
+                break;
             case "memberEvent":
                 this.handleMemberEvent(sender, member, msg);
                 break;
@@ -203,7 +204,7 @@ class Collaboration {
         switch (msg.actionType) {
             case "addComment":
                 const comment = {
-                    id: nextCommentId++,
+                    id: this.nextCommentId++,
                     author: member.name,
                     time: Date.now(),
                     content: msg.content

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -417,17 +417,18 @@ function handleMessage(ws, id, msg) {
  * image ids and their names.
  */
 function getAvailable(image) {
-    const availableInStorage = autosave.getSavedIds(image);
-    const availableRunning = collabs.map(collab => {
-        return {
-            id: collab.id,
-            name: collab.name
-        };
+    return autosave.getSavedIds(image).then(availableInStorage => {
+        const availableRunning = Object.values(collabs).map(collab => {
+            return {
+                id: collab.id,
+                name: collab.name
+            };
+        });
+        const availableNotInStorage = availableRunning.filter(collab => {
+            return !availableInStorage.some(entry => entry.id === collab.id);
+        });
+        return availableInStorage.concat(availableNotInStorage);
     });
-    const availableNotInStorage = availableRunning.filter(collab => {
-        return !availableInStorage.some(entry => entry.id === collab.id);
-    });
-    return availableInStorage.concat(availableNotInStorage);
 }
 
 module.exports = function(dir) {


### PR DESCRIPTION
Added the ability to add global comments to a session, which are also stored persistently. Includes QoL features like pressing `Esc` to unfocus the comment field and `Enter` to submit a comment without pressing the "Add Comment" button.

Since the comments themselves are very similar to the comments that can be made on individual annotations, I initially tried to use the same code for both pieces of functionality, but I ended up scrapping this due to the communication with the server working too differently between the two. Since the current idea of CytoBrowser always requires a user to be connected to a session when working, I think it may be relevant to change how annotations are added (user says where annotation should go -> server broadcasts where the annotation is with an ID) in order to simplify the code at some point, which would make this shared comment section code easier to sort out.