### PR TITLE
Issue/118 metadata

### DIFF
--- a/cytobrowser.js
+++ b/cytobrowser.js
@@ -4,11 +4,13 @@ const hostname = argv._[0] || "localhost";
 const port = argv._[1] || 0;
 const storageDir = argv.storage || argv.s || "./storage";
 const collabDir = argv.collab || argv.c || "./collab_storage";
+const metadataDir = argv.metadata || argv.m || "./metadata/json";
 const dataDir = argv.data || argv.d || "./data";
 if (argv.h || argv.help) {
     console.info(`Usage: node cytobrowser.js hostname port ` +
     `[-s storage path = "./storage"] ` +
     `[-c collab storage path = "./collab_storage"] ` +
+    `[-m image json metadata path = "./metadata/json"] ` +
     `[-d image data path = "./data"]`);
     return;
 }
@@ -17,7 +19,7 @@ if (argv.h || argv.help) {
 const fs = require("fs");
 const express = require("express");
 const availableImages = require("./server/availableImages")(dataDir);
-const collaboration = require("./server/collaboration")(collabDir);
+const collaboration = require("./server/collaboration")(collabDir, metadataDir);
 const serverStorage = require("./server/serverStorage")(storageDir);
 
 // Initialize the server

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,11 @@
         "ws": "^5.2.0"
       }
     },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "express-ws": "^4.0.0",
+    "fast-xml-parser": "^3.19.0",
     "minimist": "^1.2.5",
     "sanitize-filename": "^1.6.3"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -560,6 +560,7 @@
 <script src="js/openseadragon/openseadragon-viewerinputhook.js"></script>
 <!-- <script src="js/openseadragon/openseadragon-filtering.js"></script> -->
 <script src="js/openseadragon/openseadragon-svg-overlay.js"></script>
+<script src="js/openseadragon/openseadragon-scalebar.js"></script>
 <script src="classConfig.js"></script>
 <script src="js/utils/classUtils.js"></script>
 <script src="js/collabClient.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -99,12 +99,26 @@
                             </div>
                         </div>
 
-                        <!-- Collapse for global comments -->
+                        <!-- Collapse for metadata and global comments -->
                         <button type="button" class="btn btn-block btn-primary collapsed" data-toggle="collapse" data-target="#comments_collapse">
                             <div class="d-flex flex-row w-100"><div class="w-100">Comments</div> <i class="collapse_rotate fa fa-chevron-down pull-right pt-1"></i></div>
                         </button>
                         <div class="m-2">
                             <div class="collapse card" id="comments_collapse">
+                                <div class="card-body">
+                                    <div class="d-flex justify-content-between">
+                                        <span>Resolution:</span>
+                                        <span id="metadata_resolution">-</span>
+                                    </div>
+                                    <div class="d-flex justify-content-between">
+                                        <span>Number of markers:</span>
+                                        <span id="metadata_nmarkers">-</span>
+                                    </div>
+                                    <div class="d-flex justify-content-between">
+                                        <span>Number of regions:</span>
+                                        <span id="metadata_nregions">-</span>
+                                    </div>
+                                </div>
                                 <div class="card-body" id="global_comments">
                                     <!-- Comments -->
                                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -105,44 +105,64 @@
                         </button>
                         <div class="m-0 my-2">
                             <div class="collapse card" id="comments_collapse">
-                                <div class="card-body">
-                                    <div class="d-flex justify-content-between">
-                                        <span>Resolution:</span>
-                                        <span id="metadata_resolution">-</span>
-                                    </div>
-                                    <div class="d-flex justify-content-between">
-                                        <span>Physical size:</span>
-                                        <span id="metadata_size">-</span>
-                                    </div>
-                                    <div class="d-flex justify-content-between">
-                                        <span>Acquisition date:</span>
-                                        <span id="metadata_date">-</span>
-                                    </div>
-                                    <div class="d-flex justify-content-between">
-                                        <span>Microscope model:</span>
-                                        <span id="metadata_microscope">-</span>
-                                    </div>
-                                    <div class="d-flex justify-content-between">
-                                        <span>Nominal magnification:</span>
-                                        <span id="metadata_magnification">-</span>
-                                    </div>
-                                    <div class="d-flex justify-content-between">
-                                        <span>Color depth:</span>
-                                        <span id="metadata_sigbits">-</span>
-                                    </div>
-                                    <div class="d-flex justify-content-between">
-                                        <span>Number of channels:</span>
-                                        <span id="metadata_nchannels">-</span>
-                                    </div>
-                                    <div class="d-flex justify-content-between">
-                                        <span>Number of markers:</span>
-                                        <span id="metadata_nmarkers">-</span>
-                                    </div>
-                                    <div class="d-flex justify-content-between">
-                                        <span>Number of regions:</span>
-                                        <span id="metadata_nregions">-</span>
-                                    </div>
-                                </div>
+                                <table class="table table-striped table-borderless">
+                                    <tbody>
+                                        <tr><td class="py-1">
+                                            <div class="d-flex justify-content-between">
+                                                <span>Resolution:</span>
+                                                <span id="metadata_resolution">-</span>
+                                            </div>
+                                        </td></tr>
+                                        <tr><td class="py-1">
+                                            <div class="d-flex justify-content-between">
+                                                <span>Physical size:</span>
+                                                <span id="metadata_size">-</span>
+                                            </div>
+                                        </td></tr>
+                                        <tr><td class="py-1">
+                                            <div class="d-flex justify-content-between">
+                                                <span>Acquisition date:</span>
+                                                <span id="metadata_date">-</span>
+                                            </div>
+                                        </td></tr>
+                                        <tr><td class="py-1">
+                                            <div class="d-flex justify-content-between">
+                                                <span>Microscope model:</span>
+                                                <span id="metadata_microscope">-</span>
+                                            </div>
+                                        </td></tr>
+                                        <tr><td class="py-1">
+                                            <div class="d-flex justify-content-between">
+                                                <span>Nominal magnification:</span>
+                                                <span id="metadata_magnification">-</span>
+                                            </div>
+                                        </td></tr>
+                                        <tr><td class="py-1">
+                                            <div class="d-flex justify-content-between">
+                                                <span>Color depth:</span>
+                                                <span id="metadata_sigbits">-</span>
+                                            </div>
+                                        </td></tr>
+                                        <tr><td class="py-1">
+                                            <div class="d-flex justify-content-between">
+                                                <span>Number of channels:</span>
+                                                <span id="metadata_nchannels">-</span>
+                                            </div>
+                                        </td></tr>
+                                        <tr><td class="py-1">
+                                            <div class="d-flex justify-content-between">
+                                                <span>Number of markers:</span>
+                                                <span id="metadata_nmarkers">-</span>
+                                            </div>
+                                        </td></tr>
+                                        <tr><td class="py-1">
+                                            <div class="d-flex justify-content-between">
+                                                <span>Number of regions:</span>
+                                                <span id="metadata_nregions">-</span>
+                                            </div>
+                                        </td></tr>
+                                    </tbody>
+                                </table>
                                 <div class="card-body p-2" id="global_comments">
                                     <!-- Comments -->
                                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -99,9 +99,9 @@
                             </div>
                         </div>
 
-                        <!-- Collapse for metadata and global comments -->
+                        <!-- Collapse for metadata and global comments and metadata -->
                         <button type="button" class="btn btn-block btn-primary collapsed" data-toggle="collapse" data-target="#comments_collapse">
-                            <div class="d-flex flex-row w-100"><div class="w-100">Comments</div> <i class="collapse_rotate fa fa-chevron-down pull-right pt-1"></i></div>
+                            <div class="d-flex flex-row w-100"><div class="w-100">Global Data</div> <i class="collapse_rotate fa fa-chevron-down pull-right pt-1"></i></div>
                         </button>
                         <div class="m-0 my-2">
                             <div class="collapse card" id="comments_collapse">

--- a/public/index.html
+++ b/public/index.html
@@ -111,6 +111,30 @@
                                         <span id="metadata_resolution">-</span>
                                     </div>
                                     <div class="d-flex justify-content-between">
+                                        <span>Physical size:</span>
+                                        <span id="metadata_size">-</span>
+                                    </div>
+                                    <div class="d-flex justify-content-between">
+                                        <span>Acquisition date:</span>
+                                        <span id="metadata_date">-</span>
+                                    </div>
+                                    <div class="d-flex justify-content-between">
+                                        <span>Microscope model:</span>
+                                        <span id="metadata_microscope">-</span>
+                                    </div>
+                                    <div class="d-flex justify-content-between">
+                                        <span>Nominal magnification:</span>
+                                        <span id="metadata_magnification">-</span>
+                                    </div>
+                                    <div class="d-flex justify-content-between">
+                                        <span>Color depth:</span>
+                                        <span id="metadata_sigbits">-</span>
+                                    </div>
+                                    <div class="d-flex justify-content-between">
+                                        <span>Number of channels:</span>
+                                        <span id="metadata_nchannels">-</span>
+                                    </div>
+                                    <div class="d-flex justify-content-between">
                                         <span>Number of markers:</span>
                                         <span id="metadata_nmarkers">-</span>
                                     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -584,6 +584,7 @@
 <script src="classConfig.js"></script>
 <script src="js/utils/classUtils.js"></script>
 <script src="js/collabClient.js"></script>
+<script src="js/globalDataHandler.js"></script>
 <script src="js/metadataHandler.js"></script>
 <script src="js/annotationHandler.js"></script>
 <script src="js/overlayHandler.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -58,15 +58,15 @@
     </nav>
 
     <!-- Main content -->
-    <div id="main_content" class="container-fluid d-flex h-100" style="min-width: 400px;" tabindex="-1">
-        <div class="row flex-fill" id="main_row">
+    <div id="main_content" class="container-fluid d-flex h-100 position-relative" style="min-width: 400px;" tabindex="-1">
+        <div id="main_row" class="row flex-fill position-absolute m-0" style="right: 0; top: 0; left: 0; bottom: 0;">
             <div class="col md-10 px-1" style="min-width: 50%; min-height: 85%; width: 100%; overflow: hidden; flex-grow: 100;"> <!-- Doesn't make sense to have overflow of the viewer -->
                 <div id="ISS_viewer" class="ISS_viewer blurrable flex-grow-1 h-100 w-100"></div>
                 <div id="alert_wrapper" style="height: 100%; width: 100%; display: flex; justify-content: center; align-items: center; position: absolute; top: 0; padding: 5%; pointer-events: none"></div>
             </div>
 
             <!-- Right side main toolbar -->
-            <div class="col-auto d-flex flex-column md-2 pt-2 pl-0 pr-1" style="overflow-y:auto; overflow-x:hidden; flex-grow: 1;" id="rtoolbar">
+            <div class="col-auto d-flex flex-column md-2 pt-2 pl-0 pr-1 h-100" style="overflow-y:auto; overflow-x:hidden; flex-grow: 1;" id="rtoolbar">
                 <div class="card w-100">
                     <!-- Modal access -->
                     <div class="card-body pb-2 px-2">

--- a/public/js/annotationHandler.js
+++ b/public/js/annotationHandler.js
@@ -205,7 +205,7 @@ const annotationHandler = (function (){
         _annotations.push(addedAnnotation);
 
         // Update the annotation count
-        if (addedAnnotation.points === 1) {
+        if (addedAnnotation.points.length === 1) {
             _nMarkers++;
         }
         else {
@@ -287,7 +287,7 @@ const annotationHandler = (function (){
         }
 
         // Remove the annotation from the data
-        const removedAnnotation = annotations.splice(deletedIndex, 1);
+        const removedAnnotation = annotations.splice(deletedIndex, 1)[0];
 
         // Update the annotation count
         if (removedAnnotation.points.length === 1) {

--- a/public/js/annotationHandler.js
+++ b/public/js/annotationHandler.js
@@ -35,6 +35,16 @@ const annotationHandler = (function (){
      * @typedef {string} CoordSystem
      */
     const _annotations = [];
+    let _nMarkers = 0;
+    let _nRegions = 0;
+
+    function _updateMetadata() {
+        metadataHandler.updateMetadataValues({
+            nMarkers: _nMarkers,
+            nRegions: _nRegions
+        });
+    }
+
     function _generateId() {
         const order = Math.ceil(Math.log10((1 + _annotations.length) * 100));
         const multiplier = Math.pow(10, order);
@@ -194,6 +204,15 @@ const annotationHandler = (function (){
         // Store a data representation of the annotation
         _annotations.push(addedAnnotation);
 
+        // Update the annotation count
+        if (addedAnnotation.points === 1) {
+            _nMarkers++;
+        }
+        else {
+            _nRegions++;
+        }
+        _updateMetadata();
+
         // Send the update to collaborators
         transmit && collabClient.addAnnotation(addedAnnotation);
 
@@ -268,7 +287,16 @@ const annotationHandler = (function (){
         }
 
         // Remove the annotation from the data
-        annotations.splice(deletedIndex, 1);
+        const removedAnnotation = annotations.splice(deletedIndex, 1);
+
+        // Update the annotation count
+        if (removedAnnotation.points.length === 1) {
+            _nMarkers--;
+        }
+        else {
+            _nRegions--;
+        }
+        _updateMetadata();
 
         // Send the update to collaborators
         transmit && collabClient.removeAnnotation(id);

--- a/public/js/annotationStorageConversion.js
+++ b/public/js/annotationStorageConversion.js
@@ -35,7 +35,7 @@ const annotationStorageConversion = (function() {
                 });
                 if (data.version === "1.1") {
                     data.comments.forEach(comment => {
-                        metadataHandler.handleCommentFromServer(comment);
+                        globalDataHandler.handleCommentFromServer(comment);
                     });
                 }
             }
@@ -55,7 +55,7 @@ const annotationStorageConversion = (function() {
                         label: "Replace existing annotations with loaded ones",
                         click: () => {
                             annotationHandler.clear();
-                            metadataHandler.clear();
+                            globalDataHandler.clear();
                             addAnnotations();
                         }
                     }
@@ -84,7 +84,7 @@ const annotationStorageConversion = (function() {
         annotationHandler.forEachAnnotation(annotation => {
             data.annotations.push(annotation)
         });
-        metadataHandler.forEachComment(comment => {
+        globalDataHandler.forEachComment(comment => {
             data.comments.push(comment)
         });
         return data;

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -164,6 +164,7 @@ const collabClient = (function(){
             });
         }
         metadataHandler.clear();
+        metadataHandler.updateMetadataValues(msg.metadata);
         annotationHandler.clear(false);
         msg.annotations.forEach(annotation => {
             annotationHandler.add(annotation, "image", false)

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -80,10 +80,10 @@ const collabClient = (function(){
     function _handleMetadataAction(msg) {
         switch(msg.actionType) {
             case "addComment":
-                metadataHandler.handleCommentFromServer(msg.comment);
+                globalDataHandler.handleCommentFromServer(msg.comment);
                 break;
             case "removeComment":
-                metadataHandler.handleCommentRemovalFromServer(msg.id);
+                globalDataHandler.handleCommentRemovalFromServer(msg.id);
                 break;
             default:
                 console.warn(`Unknown metadata action type: ${msg.actionType}`);
@@ -176,7 +176,7 @@ const collabClient = (function(){
             _joinBatch = null;
         }
         msg.comments.forEach(comment => {
-            metadataHandler.handleCommentFromServer(comment);
+            globalDataHandler.handleCommentFromServer(comment);
         });
         _members = msg.members;
         _localMember = _members.find(member => member.id === msg.requesterId);

--- a/public/js/collabClient.js
+++ b/public/js/collabClient.js
@@ -164,6 +164,7 @@ const collabClient = (function(){
             });
         }
         metadataHandler.clear();
+        globalDataHandler.clear();
         metadataHandler.updateMetadataValues(msg.metadata);
         annotationHandler.clear(false);
         msg.annotations.forEach(annotation => {

--- a/public/js/globalDataHandler.js
+++ b/public/js/globalDataHandler.js
@@ -1,0 +1,96 @@
+/**
+ * Namespace for handling the global data of a collaboration.
+ * @namespace globalDataHandler
+ */
+const globalDataHandler = (function() {
+   const _comments = [];
+   let _updateFun = null;
+
+   function _updateCommentSection() {
+       if (!_updateFun) {
+           console.warn("Could not handle comment as there is no update function set.");
+       }
+       else {
+           _updateFun(_comments);
+       }
+   }
+
+   /**
+    * Submit a comment that should be added to the global comments of
+    * the current session.
+    * @param {string} commentText The text of the comment being submitted.
+    */
+   function sendCommentToServer(commentText) {
+       collabClient.addComment(commentText);
+   }
+
+   /**
+    * Tell the server that a comment should be deleted.
+    * @param {number} id The id of the comment to be removed.
+    */
+   function sendCommentRemovalToServer(id) {
+       collabClient.removeComment(id);
+   }
+
+   /**
+    * Receive a comment from the server and display it in the global
+    * comment section.
+    * @param {Object} comment The new comment to be added.
+    */
+   function handleCommentFromServer(comment) {
+       _comments.push(comment);
+       _updateCommentSection();
+   }
+
+   /**
+    * Receive a comment removal instruction from the server.
+    * @param {number} id The id of the comment to be removed.
+    */
+   function handleCommentRemovalFromServer(id) {
+       const commentIndex = _comments.findIndex(comment =>
+           comment.id === id
+       );
+       if (commentIndex >= 0) {
+           _comments.splice(commentIndex, 1);
+           _updateCommentSection();
+       }
+       else {
+           throw Error("Server tried to delete a comment that doesn't exist locally.");
+       }
+   }
+
+   /**
+    * Set the function that should be called with the comment list
+    * whenever the comments are updated.
+    * @param {Function} updateFun The new update function.
+    */
+   function setCommentUpdateFun(updateFun) {
+       _updateFun = updateFun;
+   }
+
+   /**
+    * Iterate some function over copies of all global comments.
+    * @param {Function} f The function to be called on all comments.
+    */
+   function forEachComment(f) {
+       _comments.forEach(comment => f(Object.assign({}, comment)));
+   }
+
+   /**
+    * Clear the currently set metadata.
+    **/
+   function clear() {
+       _comments.length = 0;
+       _updateCommentSection();
+   }
+
+   return {
+       sendCommentToServer: sendCommentToServer,
+       sendCommentRemovalToServer: sendCommentRemovalToServer,
+       handleCommentFromServer: handleCommentFromServer,
+       handleCommentRemovalFromServer: handleCommentRemovalFromServer,
+       setCommentUpdateFun: setCommentUpdateFun,
+       forEachComment: forEachComment,
+       clear: clear
+   };
+})();

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -96,7 +96,7 @@ const htmlHelper = (function() {
 
     function _commentListAlt(removeFun) {
         const container = $(`
-            <div class="card bg-secondary mb-2" style="height: 15vh; overflow-y: auto;">
+            <div class="card bg-secondary mb-2" style="height: 15vh; overflow-y: auto; resize: vertical;">
                 <ul class="list-group list-group-flush position-absolute w-100">
                 </ul>
             </div>
@@ -152,7 +152,7 @@ const htmlHelper = (function() {
     function _commentInputAlt(inputFun) {
         const container = $(`
             <div class="input-group">
-                <textarea class="form-control" rows="1" style="resize: none;"></textarea>
+                <textarea class="form-control" rows="1" style="resize: vertical;"></textarea>
                 <div class="input-group-append">
                     <button type="button" class="btn btn-primary">Add comment</button>
                 </div>

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -17,11 +17,29 @@ const metadataHandler = (function() {
     }
 
     function _metadataValuesAsReadable() {
-        const res = _metadataValues.resolution;
+        const date = _metadataValues.AcquisitionDate;
+        const microscope = _metadataValues.MicroscopeModel;
+        const magnification = _metadataValues.NominalMagnification;
+        const size = {
+            x: _metadataValues.PhysicalSizeX + _metadataValues.PhysicalSizeXUnit,
+            y: _metadataValues.PhysicalSizeY + _metadataValues.PhysicalSizeYUnit
+        };
+        const sigbits = _metadataValues.SignificantBits;
+        const nChannels = _metadataValues.SizeC;
+        const res = {
+            x: _metadataValues.SizeX,
+            y: _metadataValues.SizeY,
+        };
         const nMarkers = _metadataValues.nMarkers;
         const nRegions = _metadataValues.nRegions;
         const readableValues = {
             resolution: res ? `${res.x} &#215; ${res.y}` : "-",
+            size: size ? `${size.x} &#215; ${size.y}` : "-",
+            date: date ? date : "-",
+            microscope: microscope ? microscope : "-",
+            magnification: magnification ? magnification : "-",
+            sigbits: `${sigbits} bits` : "-",
+            nChannels: nChannels : "-",
             nMarkers: nMarkers || nMarkers === 0 ? nMarkers : "-",
             nRegions: nRegions || nRegions === 0 ? nRegions : "-"
         };
@@ -31,6 +49,12 @@ const metadataHandler = (function() {
     function _updateDisplayedMetadataValues() {
         const readableValues = _metadataValuesAsReadable();
         $("#metadata_resolution").html(readableValues.resolution);
+        $("#metadata_size").html(readableValues.size);
+        $("#metadata_date").html(readableValues.date);
+        $("#metadata_microscope").html(readableValues.microscope);
+        $("#metadata_magnification").html(readableValues.magnification);
+        $("#metadata_sigbits").html(readableValues.sigbits);
+        $("#metadata_nchannels").html(readableValues.nChannels);
         $("#metadata_nmarkers").html(readableValues.nMarkers);
         $("#metadata_nregions").html(readableValues.nRegions);
     }

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -21,8 +21,8 @@ const metadataHandler = (function() {
         const microscope = _metadataValues.MicroscopeModel;
         const magnification = _metadataValues.NominalMagnification;
         const size = {
-            x: _metadataValues.PhysicalSizeX + _metadataValues.PhysicalSizeXUnit,
-            y: _metadataValues.PhysicalSizeY + _metadataValues.PhysicalSizeYUnit
+            x: _metadataValues.PhysicalSizeX.toPrecision(4) + _metadataValues.PhysicalSizeXUnit,
+            y: _metadataValues.PhysicalSizeY.toPrecision(4) + _metadataValues.PhysicalSizeYUnit
         };
         const sigbits = _metadataValues.SignificantBits;
         const nChannels = _metadataValues.SizeC;
@@ -37,9 +37,9 @@ const metadataHandler = (function() {
             size: size ? `${size.x} &#215; ${size.y}` : "-",
             date: date ? date : "-",
             microscope: microscope ? microscope : "-",
-            magnification: magnification ? magnification : "-",
-            sigbits: `${sigbits} bits` : "-",
-            nChannels: nChannels : "-",
+            magnification: magnification ? `${magnification}x` : "-",
+            sigbits: sigbits ? `${sigbits} bits` : "-",
+            nChannels: nChannels ? nChannels : "-",
             nMarkers: nMarkers || nMarkers === 0 ? nMarkers : "-",
             nRegions: nRegions || nRegions === 0 ? nRegions : "-"
         };

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -1,9 +1,8 @@
 /**
- * Namespace for handling the metadata of a slide and collaboration.
+ * Namespace for handling the metadata of a slide.
  * @namespace metadataHandler
  */
 const metadataHandler = (function() {
-    const _comments = [];
     const _metadataValues = {};
     // Can come up with a more thorough way of doing this if needed
     const _units = {
@@ -15,16 +14,6 @@ const metadataHandler = (function() {
         "Mm": 1e6,
         "Gm": 1e9
     };
-    let _updateFun = null;
-
-    function _updateCommentSection() {
-        if (!_updateFun) {
-            console.warn("Could not handle comment as there is no update function set.");
-        }
-        else {
-            _updateFun(_comments);
-        }
-    }
 
     function _metadataValuesAsReadable() {
         const res = {
@@ -81,67 +70,6 @@ const metadataHandler = (function() {
     }
 
     /**
-     * Submit a comment that should be added to the global comments of
-     * the current session.
-     * @param {string} commentText The text of the comment being submitted.
-     */
-    function sendCommentToServer(commentText) {
-        collabClient.addComment(commentText);
-    }
-
-    /**
-     * Tell the server that a comment should be deleted.
-     * @param {number} id The id of the comment to be removed.
-     */
-    function sendCommentRemovalToServer(id) {
-        collabClient.removeComment(id);
-    }
-
-    /**
-     * Receive a comment from the server and display it in the global
-     * comment section.
-     * @param {Object} comment The new comment to be added.
-     */
-    function handleCommentFromServer(comment) {
-        _comments.push(comment);
-        _updateCommentSection();
-    }
-
-    /**
-     * Receive a comment removal instruction from the server.
-     * @param {number} id The id of the comment to be removed.
-     */
-    function handleCommentRemovalFromServer(id) {
-        const commentIndex = _comments.findIndex(comment =>
-            comment.id === id
-        );
-        if (commentIndex >= 0) {
-            _comments.splice(commentIndex, 1);
-            _updateCommentSection();
-        }
-        else {
-            throw Error("Server tried to delete a comment that doesn't exist locally.");
-        }
-    }
-
-    /**
-     * Set the function that should be called with the comment list
-     * whenever the comments are updated.
-     * @param {Function} updateFun The new update function.
-     */
-    function setCommentUpdateFun(updateFun) {
-        _updateFun = updateFun;
-    }
-
-    /**
-     * Iterate some function over copies of all global comments.
-     * @param {Function} f The function to be called on all comments.
-     */
-    function forEachComment(f) {
-        _comments.forEach(comment => f(Object.assign({}, comment)));
-    }
-
-    /**
      * Update the metadata values and display them in the user interface.
      * Values that are not specified will remain as they are.
      * @param {Object} newValues New values for some or all of the
@@ -157,8 +85,6 @@ const metadataHandler = (function() {
      * Clear the currently set metadata.
      **/
     function clear() {
-        _comments.length = 0;
-        _updateCommentSection();
         // TODO: Metadata values should be cleared separately
     }
 

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -17,19 +17,20 @@ const metadataHandler = (function() {
     }
 
     function _metadataValuesAsReadable() {
-        const date = _metadataValues.AcquisitionDate;
-        const microscope = _metadataValues.MicroscopeModel;
-        const magnification = _metadataValues.NominalMagnification;
-        const size = {
-            x: _metadataValues.PhysicalSizeX.toPrecision(4) + _metadataValues.PhysicalSizeXUnit,
-            y: _metadataValues.PhysicalSizeY.toPrecision(4) + _metadataValues.PhysicalSizeYUnit
-        };
-        const sigbits = _metadataValues.SignificantBits;
-        const nChannels = _metadataValues.SizeC;
         const res = {
             x: _metadataValues.SizeX,
             y: _metadataValues.SizeY,
         };
+        // TODO: Long line
+        const size = {
+            x: _metadataValues.PhysicalSizeX && res.x * _metadataValues.PhysicalSizeX.toPrecision(4) + _metadataValues.PhysicalSizeXUnit,
+            y: _metadataValues.PhysicalSizeY && res.y * _metadataValues.PhysicalSizeY.toPrecision(4) + _metadataValues.PhysicalSizeYUnit
+        };
+        const date = _metadataValues.AcquisitionDate;
+        const microscope = _metadataValues.MicroscopeModel;
+        const magnification = _metadataValues.NominalMagnification;
+        const sigbits = _metadataValues.SignificantBits;
+        const nChannels = _metadataValues.SizeC;
         const nMarkers = _metadataValues.nMarkers;
         const nRegions = _metadataValues.nRegions;
         const readableValues = {

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -5,6 +5,16 @@
 const metadataHandler = (function() {
     const _comments = [];
     const _metadataValues = {};
+    // Can come up with a more thorough way of doing this if needed
+    const _units = {
+        "nm": 10e9,
+        "µm": 10e-6,
+        "mm": 10e-3,
+        "m": 10e0,
+        "km": 10e3,
+        "Mm": 10e6,
+        "Gm": 10e9
+    };
     let _updateFun = null;
 
     function _updateCommentSection() {
@@ -58,6 +68,16 @@ const metadataHandler = (function() {
         $("#metadata_nchannels").html(readableValues.nChannels);
         $("#metadata_nmarkers").html(readableValues.nMarkers);
         $("#metadata_nregions").html(readableValues.nRegions);
+    }
+
+    function _updateScalebar() {
+        if (_metadataValues.PhysicalSizeX && _metadataValues.PhislcalSizeXUnit) {
+            const size = _metadataValues.PhysicalSizeX;
+            const scale = _units[_metadataValues.PhislcalSizeXUnit];
+            const metersPerPixel = size * scale;
+            const pixelsPerMeter = 1 / metersPerPixel;
+            tmapp.updateScalebar(pixelsPerMeter);
+        }
     }
 
     /**
@@ -130,6 +150,7 @@ const metadataHandler = (function() {
     function updateMetadataValues(newValues) {
         Object.assign(_metadataValues, newValues);
         _updateDisplayedMetadataValues();
+        _updateScalebar();
     }
 
     /**

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -4,6 +4,7 @@
  */
 const metadataHandler = (function() {
     const _comments = [];
+    const _metadataValues = {};
     let _updateFun = null;
 
     function _updateCommentSection() {
@@ -13,6 +14,18 @@ const metadataHandler = (function() {
         else {
             _updateFun(_comments);
         }
+    }
+
+    function _metadataValuesAsReadable() {
+        const res = _metadataValues.resolution;
+        const nMarkers = _metadataValues.nMarkers;
+        const nRegions = _metadataValues.nRegions;
+        const readableValues = {
+            resolution: res ? `${res.x} &#215; ${res.y}` : "-",
+            nMarkers: nMarkers || nMarkers === 0 ? nMarkers : "-",
+            nRegions: nRegions || nRegions === 0 ? nRegions : "-"
+        };
+        return readableValues;
     }
 
     /**
@@ -76,9 +89,27 @@ const metadataHandler = (function() {
         _comments.forEach(comment => f(Object.assign({}, comment)));
     }
 
+    /**
+     * Update the metadata values and display them in the user interface.
+     * Values that are not specified will remain as they are.
+     * @param {Object} newValues New values for some or all of the
+     * metadata values.
+     */
+    function updateMetadataValues(newValues) {
+        Object.assign(_metadataValues, newValues);
+        const readableValues = _metadataValuesAsReadable();
+        $("#metadata_resolution").html(readableValues.resolution);
+        $("#metadata_nmarkers").html(readableValues.nMarkers);
+        $("#metadata_nregions").html(readableValues.nRegions);
+    }
+
+    /**
+     * Clear the currently set metadata.
+     **/
     function clear() {
         _comments.length = 0;
         _updateCommentSection();
+        // TODO: Clear metadata values
     }
 
     return {
@@ -88,6 +119,7 @@ const metadataHandler = (function() {
         handleCommentRemovalFromServer: handleCommentRemovalFromServer,
         setCommentUpdateFun: setCommentUpdateFun,
         forEachComment: forEachComment,
+        updateMetadataValues: updateMetadataValues,
         clear: clear
     };
 })();

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -33,8 +33,8 @@ const metadataHandler = (function() {
         };
         // TODO: Long line
         const size = {
-            x: (_metadataValues.PhysicalSizeX && res.x * _metadataValues.PhysicalSizeX).toPrecision(4) + _metadataValues.PhysicalSizeXUnit,
-            y: (_metadataValues.PhysicalSizeY && res.y * _metadataValues.PhysicalSizeY).toPrecision(4) + _metadataValues.PhysicalSizeYUnit
+            x: Number((_metadataValues.PhysicalSizeX && res.x * _metadataValues.PhysicalSizeX).toPrecision(4)) + _metadataValues.PhysicalSizeXUnit,
+            y: Number((_metadataValues.PhysicalSizeY && res.y * _metadataValues.PhysicalSizeY).toPrecision(4)) + _metadataValues.PhysicalSizeYUnit
         };
         const date = _metadataValues.AcquisitionDate;
         const microscope = _metadataValues.MicroscopeModel;

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -112,11 +112,8 @@ const metadataHandler = (function() {
      **/
     function clear() {
         _comments.length = 0;
-        Object.keys(_metadataValues).forEach(key =>
-            _metadataValues[key] = null
-        );
         _updateCommentSection();
-        _updateDisplayedMetadataValues();
+        // TODO: Metadata values should be cleared separately
     }
 
     return {

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -16,14 +16,21 @@ const metadataHandler = (function() {
     };
 
     function _metadataValuesAsReadable() {
-        const res = {
-            x: _metadataValues.SizeX,
-            y: _metadataValues.SizeY,
+        const res =
+            _metadataValues.SizeX &&
+            _metadataValues.SizeY &&
+            {
+                x: _metadataValues.SizeX,
+                y: _metadataValues.SizeY,
         };
-        // TODO: Long line
-        const size = {
-            x: Number((_metadataValues.PhysicalSizeX && res.x * _metadataValues.PhysicalSizeX).toPrecision(4)) + _metadataValues.PhysicalSizeXUnit,
-            y: Number((_metadataValues.PhysicalSizeY && res.y * _metadataValues.PhysicalSizeY).toPrecision(4)) + _metadataValues.PhysicalSizeYUnit
+        const size =
+            _metadataValues.PhysicalSizeX &&
+            _metadataValues.PhysicalSizeY &&
+            _metadataValues.PhysicalSizeXUnit &&
+            _metadataValues.PhysicalSizeYUnit &&
+            {
+                x: Number((res.x * _metadataValues.PhysicalSizeX).toPrecision(4)) + _metadataValues.PhysicalSizeXUnit,
+                y: Number((res.y * _metadataValues.PhysicalSizeY).toPrecision(4)) + _metadataValues.PhysicalSizeYUnit
         };
         const date = _metadataValues.AcquisitionDate;
         const microscope = _metadataValues.MicroscopeModel;

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -89,12 +89,6 @@ const metadataHandler = (function() {
     }
 
     return {
-        sendCommentToServer: sendCommentToServer,
-        sendCommentRemovalToServer: sendCommentRemovalToServer,
-        handleCommentFromServer: handleCommentFromServer,
-        handleCommentRemovalFromServer: handleCommentRemovalFromServer,
-        setCommentUpdateFun: setCommentUpdateFun,
-        forEachComment: forEachComment,
         updateMetadataValues: updateMetadataValues,
         clear: clear
     };

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -7,13 +7,13 @@ const metadataHandler = (function() {
     const _metadataValues = {};
     // Can come up with a more thorough way of doing this if needed
     const _units = {
-        "nm": 10e9,
-        "µm": 10e-6,
-        "mm": 10e-3,
-        "m": 10e0,
-        "km": 10e3,
-        "Mm": 10e6,
-        "Gm": 10e9
+        "nm": 1e-9,
+        "µm": 1e-6,
+        "mm": 1e-3,
+        "m": 1,
+        "km": 1e3,
+        "Mm": 1e6,
+        "Gm": 1e9
     };
     let _updateFun = null;
 
@@ -71,9 +71,9 @@ const metadataHandler = (function() {
     }
 
     function _updateScalebar() {
-        if (_metadataValues.PhysicalSizeX && _metadataValues.PhislcalSizeXUnit) {
+        if (_metadataValues.PhysicalSizeX && _metadataValues.PhysicalSizeXUnit) {
             const size = _metadataValues.PhysicalSizeX;
-            const scale = _units[_metadataValues.PhislcalSizeXUnit];
+            const scale = _units[_metadataValues.PhysicalSizeXUnit];
             const metersPerPixel = size * scale;
             const pixelsPerMeter = 1 / metersPerPixel;
             tmapp.updateScalebar(pixelsPerMeter);

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -33,8 +33,8 @@ const metadataHandler = (function() {
         };
         // TODO: Long line
         const size = {
-            x: _metadataValues.PhysicalSizeX && res.x * _metadataValues.PhysicalSizeX.toPrecision(4) + _metadataValues.PhysicalSizeXUnit,
-            y: _metadataValues.PhysicalSizeY && res.y * _metadataValues.PhysicalSizeY.toPrecision(4) + _metadataValues.PhysicalSizeYUnit
+            x: (_metadataValues.PhysicalSizeX && res.x * _metadataValues.PhysicalSizeX).toPrecision(4) + _metadataValues.PhysicalSizeXUnit,
+            y: (_metadataValues.PhysicalSizeY && res.y * _metadataValues.PhysicalSizeY).toPrecision(4) + _metadataValues.PhysicalSizeYUnit
         };
         const date = _metadataValues.AcquisitionDate;
         const microscope = _metadataValues.MicroscopeModel;

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -3,7 +3,7 @@
  * @namespace metadataHandler
  */
 const metadataHandler = (function() {
-    const _metadataValues = {};
+    let _metadataValues = {};
     // Can come up with a more thorough way of doing this if needed
     const _units = {
         "nm": 1e-9,
@@ -92,7 +92,9 @@ const metadataHandler = (function() {
      * Clear the currently set metadata.
      **/
     function clear() {
-        // TODO: Metadata values should be cleared separately
+        _metadataValues = {};
+        _updateDisplayedMetadataValues();
+        _updateScalebar();
     }
 
     return {

--- a/public/js/metadataHandler.js
+++ b/public/js/metadataHandler.js
@@ -28,6 +28,13 @@ const metadataHandler = (function() {
         return readableValues;
     }
 
+    function _updateDisplayedMetadataValues() {
+        const readableValues = _metadataValuesAsReadable();
+        $("#metadata_resolution").html(readableValues.resolution);
+        $("#metadata_nmarkers").html(readableValues.nMarkers);
+        $("#metadata_nregions").html(readableValues.nRegions);
+    }
+
     /**
      * Submit a comment that should be added to the global comments of
      * the current session.
@@ -97,10 +104,7 @@ const metadataHandler = (function() {
      */
     function updateMetadataValues(newValues) {
         Object.assign(_metadataValues, newValues);
-        const readableValues = _metadataValuesAsReadable();
-        $("#metadata_resolution").html(readableValues.resolution);
-        $("#metadata_nmarkers").html(readableValues.nMarkers);
-        $("#metadata_nregions").html(readableValues.nRegions);
+        _updateDisplayedMetadataValues();
     }
 
     /**
@@ -108,8 +112,11 @@ const metadataHandler = (function() {
      **/
     function clear() {
         _comments.length = 0;
+        Object.keys(_metadataValues).forEach(key =>
+            _metadataValues[key] = null
+        );
         _updateCommentSection();
-        // TODO: Clear metadata values
+        _updateDisplayedMetadataValues();
     }
 
     return {

--- a/public/js/openseadragon/openseadragon-scalebar.js
+++ b/public/js/openseadragon/openseadragon-scalebar.js
@@ -1,0 +1,562 @@
+/* 
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+
+/**
+ *
+ * @author Antoine Vandecreme <antoine.vandecreme@nist.gov>
+ */
+(function($) {
+
+    if (!$.version || $.version.major < 2) {
+        throw new Error('This version of OpenSeadragonScalebar requires ' +
+                'OpenSeadragon version 2.0.0+');
+    }
+
+    $.Viewer.prototype.scalebar = function(options) {
+        if (!this.scalebarInstance) {
+            options = options || {};
+            options.viewer = this;
+            this.scalebarInstance = new $.Scalebar(options);
+        } else {
+            this.scalebarInstance.refresh(options);
+        }
+    };
+
+    $.ScalebarType = {
+        NONE: 0,
+        MICROSCOPY: 1,
+        MAP: 2
+    };
+
+    $.ScalebarLocation = {
+        NONE: 0,
+        TOP_LEFT: 1,
+        TOP_RIGHT: 2,
+        BOTTOM_RIGHT: 3,
+        BOTTOM_LEFT: 4
+    };
+
+    /**
+     * 
+     * @class Scalebar
+     * @param {Object} options
+     * @param {OpenSeadragon.Viewer} options.viewer The viewer to attach this
+     * Scalebar to.
+     * @param {OpenSeadragon.ScalebarType} options.type The scale bar type.
+     * Default: microscopy
+     * @param {Integer} options.pixelsPerMeter The pixels per meter of the
+     * zoomable image at the original image size. If null, the scale bar is not
+     * displayed. default: null
+     * @param {Integer} options.referenceItemIdx Specify the item from
+     * viewer.world to which options.pixelsPerMeter is refering.
+     * default: 0
+     * @param (String} options.minWidth The minimal width of the scale bar as a
+     * CSS string (ex: 100px, 1em, 1% etc...) default: 150px
+     * @param {OpenSeadragon.ScalebarLocation} options.location The location
+     * of the scale bar inside the viewer. default: bottom left
+     * @param {Integer} options.xOffset Offset location of the scale bar along x.
+     * default: 5
+     * @param {Integer} options.yOffset Offset location of the scale bar along y.
+     * default: 5
+     * @param {Boolean} options.stayInsideImage When set to true, keep the 
+     * scale bar inside the image when zooming out. default: true
+     * @param {String} options.color The color of the scale bar using a color
+     * name or the hexadecimal format (ex: black or #000000) default: black
+     * @param {String} options.fontColor The font color. default: black
+     * @param {String} options.backgroundColor The background color. default: none
+     * @param {String} options.fontSize The font size. default: not set
+     * @param {String} options.fontFamily The font-family. default: not set
+     * @param {String} options.barThickness The thickness of the scale bar in px.
+     * default: 2
+     * @param {function} options.sizeAndTextRenderer A function which will be
+     * called to determine the size of the scale bar and it's text content.
+     * The function must have 2 parameters: the PPM at the current zoom level
+     * and the minimum size of the scale bar. It must return an object containing
+     * 2 attributes: size and text containing the size of the scale bar and the text.
+     * default: $.ScalebarSizeAndTextRenderer.METRIC_LENGTH
+     */
+    $.Scalebar = function(options) {
+        options = options || {};
+        if (!options.viewer) {
+            throw new Error("A viewer must be specified.");
+        }
+        this.viewer = options.viewer;
+
+        this.divElt = document.createElement("div");
+        this.viewer.container.appendChild(this.divElt);
+        this.divElt.style.position = "relative";
+        this.divElt.style.margin = "0";
+        this.divElt.style.pointerEvents = "none";
+
+        this.setMinWidth(options.minWidth || "150px");
+
+        this.setDrawScalebarFunction(options.type || $.ScalebarType.MICROSCOPY);
+        this.color = options.color || "black";
+        this.fontColor = options.fontColor || "black";
+        this.backgroundColor = options.backgroundColor || "none";
+        this.fontSize = options.fontSize || "";
+        this.fontFamily = options.fontFamily || "";
+        this.barThickness = options.barThickness || 2;
+        this.pixelsPerMeter = options.pixelsPerMeter || null;
+        this.referenceItemIdx = options.referenceItemIdx || 0;
+        this.location = options.location || $.ScalebarLocation.BOTTOM_LEFT;
+        this.xOffset = options.xOffset || 5;
+        this.yOffset = options.yOffset || 5;
+        this.stayInsideImage = isDefined(options.stayInsideImage) ?
+                options.stayInsideImage : true;
+        this.sizeAndTextRenderer = options.sizeAndTextRenderer ||
+                $.ScalebarSizeAndTextRenderer.METRIC_LENGTH;
+
+        var self = this;
+        this.viewer.addHandler("open", function() {
+            self.refresh();
+        });
+        this.viewer.addHandler("animation", function() {
+            self.refresh();
+        });
+        this.viewer.addHandler("resize", function() {
+            self.refresh();
+        });
+    };
+
+    $.Scalebar.prototype = {
+        updateOptions: function(options) {
+            if (!options) {
+                return;
+            }
+            if (isDefined(options.type)) {
+                this.setDrawScalebarFunction(options.type);
+            }
+            if (isDefined(options.minWidth)) {
+                this.setMinWidth(options.minWidth);
+            }
+            if (isDefined(options.color)) {
+                this.color = options.color;
+            }
+            if (isDefined(options.fontColor)) {
+                this.fontColor = options.fontColor;
+            }
+            if (isDefined(options.backgroundColor)) {
+                this.backgroundColor = options.backgroundColor;
+            }
+            if (isDefined(options.fontSize)) {
+                this.fontSize = options.fontSize;
+            }
+            if (isDefined(options.fontFamily)) {
+                this.fontFamily = options.fontFamily;
+            }
+            if (isDefined(options.barThickness)) {
+                this.barThickness = options.barThickness;
+            }
+            if (isDefined(options.pixelsPerMeter)) {
+                this.pixelsPerMeter = options.pixelsPerMeter;
+            }
+            if (isDefined(options.referenceItemIdx)) {
+                this.referenceItemIdx = options.referenceItemIdx;
+            }
+            if (isDefined(options.location)) {
+                this.location = options.location;
+            }
+            if (isDefined(options.xOffset)) {
+                this.xOffset = options.xOffset;
+            }
+            if (isDefined(options.yOffset)) {
+                this.yOffset = options.yOffset;
+            }
+            if (isDefined(options.stayInsideImage)) {
+                this.stayInsideImage = options.stayInsideImage;
+            }
+            if (isDefined(options.sizeAndTextRenderer)) {
+                this.sizeAndTextRenderer = options.sizeAndTextRenderer;
+            }
+        },
+        setDrawScalebarFunction: function(type) {
+            if (!type) {
+                this.drawScalebar = null;
+            }
+            else if (type === $.ScalebarType.MAP) {
+                this.drawScalebar = this.drawMapScalebar;
+            } else {
+                this.drawScalebar = this.drawMicroscopyScalebar;
+            }
+        },
+        setMinWidth: function(minWidth) {
+            this.divElt.style.width = minWidth;
+            // Make sure to display the element before getting is width
+            this.divElt.style.display = "";
+            this.minWidth = this.divElt.offsetWidth;
+        },
+        /**
+         * Refresh the scalebar with the options submitted.
+         * @param {Object} options
+         * @param {OpenSeadragon.ScalebarType} options.type The scale bar type.
+         * Default: microscopy
+         * @param {Integer} options.pixelsPerMeter The pixels per meter of the
+         * zoomable image at the original image size. If null, the scale bar is not
+         * displayed. default: null
+         * @param {Integer} options.referenceItemIdx Specify the item from
+         * viewer.world to which options.pixelsPerMeter is refering.
+         * default: 0
+         * @param (String} options.minWidth The minimal width of the scale bar as a
+         * CSS string (ex: 100px, 1em, 1% etc...) default: 150px
+         * @param {OpenSeadragon.ScalebarLocation} options.location The location
+         * of the scale bar inside the viewer. default: bottom left
+         * @param {Integer} options.xOffset Offset location of the scale bar along x.
+         * default: 5
+         * @param {Integer} options.yOffset Offset location of the scale bar along y.
+         * default: 5
+         * @param {Boolean} options.stayInsideImage When set to true, keep the 
+         * scale bar inside the image when zooming out. default: true
+         * @param {String} options.color The color of the scale bar using a color
+         * name or the hexadecimal format (ex: black or #000000) default: black
+         * @param {String} options.fontColor The font color. default: black
+         * @param {String} options.backgroundColor The background color. default: none
+         * @param {String} options.fontSize The font size. default: not set
+         * @param {String} options.barThickness The thickness of the scale bar in px.
+         * default: 2
+         * @param {function} options.sizeAndTextRenderer A function which will be
+         * called to determine the size of the scale bar and it's text content.
+         * The function must have 2 parameters: the PPM at the current zoom level
+         * and the minimum size of the scale bar. It must return an object containing
+         * 2 attributes: size and text containing the size of the scale bar and the text.
+         * default: $.ScalebarSizeAndTextRenderer.METRIC_LENGTH
+         */
+        refresh: function(options) {
+            this.updateOptions(options);
+
+            if (!this.viewer.isOpen() ||
+                    !this.drawScalebar ||
+                    !this.pixelsPerMeter ||
+                    !this.location) {
+                this.divElt.style.display = "none";
+                return;
+            }
+            this.divElt.style.display = "";
+
+            var viewport = this.viewer.viewport;
+            var tiledImage = this.viewer.world.getItemAt(this.referenceItemIdx);
+            var zoom = tiledImageViewportToImageZoom(tiledImage,
+                    viewport.getZoom(true));
+            var currentPPM = zoom * this.pixelsPerMeter;
+            var props = this.sizeAndTextRenderer(currentPPM, this.minWidth);
+
+            this.drawScalebar(props.size, props.text);
+            var location = this.getScalebarLocation();
+            this.divElt.style.left = location.x + "px";
+            this.divElt.style.top = location.y + "px";
+        },
+        drawMicroscopyScalebar: function(size, text) {
+            this.divElt.style.fontSize = this.fontSize;
+            this.divElt.style.fontFamily = this.fontFamily;
+            this.divElt.style.textAlign = "center";
+            this.divElt.style.color = this.fontColor;
+            this.divElt.style.border = "none";
+            this.divElt.style.borderBottom = this.barThickness + "px solid " + this.color;
+            this.divElt.style.backgroundColor = this.backgroundColor;
+            this.divElt.innerHTML = text;
+            this.divElt.style.width = size + "px";
+        },
+        drawMapScalebar: function(size, text) {
+            this.divElt.style.fontSize = this.fontSize;
+            this.divElt.style.fontFamily = this.fontFamily;
+            this.divElt.style.textAlign = "center";
+            this.divElt.style.color = this.fontColor;
+            this.divElt.style.border = this.barThickness + "px solid " + this.color;
+            this.divElt.style.borderTop = "none";
+            this.divElt.style.backgroundColor = this.backgroundColor;
+            this.divElt.innerHTML = text;
+            this.divElt.style.width = size + "px";
+        },
+        /**
+         * Compute the location of the scale bar.
+         * @returns {OpenSeadragon.Point}
+         */
+        getScalebarLocation: function() {
+            if (this.location === $.ScalebarLocation.TOP_LEFT) {
+                var x = 0;
+                var y = 0;
+                if (this.stayInsideImage) {
+                    var pixel = this.viewer.viewport.pixelFromPoint(
+                            new $.Point(0, 0), true);
+                    if (!this.viewer.wrapHorizontal) {
+                        x = Math.max(pixel.x, 0);
+                    }
+                    if (!this.viewer.wrapVertical) {
+                        y = Math.max(pixel.y, 0);
+                    }
+                }
+                return new $.Point(x + this.xOffset, y + this.yOffset);
+            }
+            if (this.location === $.ScalebarLocation.TOP_RIGHT) {
+                var barWidth = this.divElt.offsetWidth;
+                var container = this.viewer.container;
+                var x = container.offsetWidth - barWidth;
+                var y = 0;
+                if (this.stayInsideImage) {
+                    var pixel = this.viewer.viewport.pixelFromPoint(
+                            new $.Point(1, 0), true);
+                    if (!this.viewer.wrapHorizontal) {
+                        x = Math.min(x, pixel.x - barWidth);
+                    }
+                    if (!this.viewer.wrapVertical) {
+                        y = Math.max(y, pixel.y);
+                    }
+                }
+                return new $.Point(x - this.xOffset, y + this.yOffset);
+            }
+            if (this.location === $.ScalebarLocation.BOTTOM_RIGHT) {
+                var barWidth = this.divElt.offsetWidth;
+                var barHeight = this.divElt.offsetHeight;
+                var container = this.viewer.container;
+                var x = container.offsetWidth - barWidth;
+                var y = container.offsetHeight - barHeight;
+                if (this.stayInsideImage) {
+                    var pixel = this.viewer.viewport.pixelFromPoint(
+                            new $.Point(1, 1 / this.viewer.source.aspectRatio),
+                            true);
+                    if (!this.viewer.wrapHorizontal) {
+                        x = Math.min(x, pixel.x - barWidth);
+                    }
+                    if (!this.viewer.wrapVertical) {
+                        y = Math.min(y, pixel.y - barHeight);
+                    }
+                }
+                return new $.Point(x - this.xOffset, y - this.yOffset);
+            }
+            if (this.location === $.ScalebarLocation.BOTTOM_LEFT) {
+                var barHeight = this.divElt.offsetHeight;
+                var container = this.viewer.container;
+                var x = 0;
+                var y = container.offsetHeight - barHeight;
+                if (this.stayInsideImage) {
+                    var pixel = this.viewer.viewport.pixelFromPoint(
+                            new $.Point(0, 1 / this.viewer.source.aspectRatio),
+                            true);
+                    if (!this.viewer.wrapHorizontal) {
+                        x = Math.max(x, pixel.x);
+                    }
+                    if (!this.viewer.wrapVertical) {
+                        y = Math.min(y, pixel.y - barHeight);
+                    }
+                }
+                return new $.Point(x + this.xOffset, y - this.yOffset);
+            }
+        },
+        /**
+         * Get the rendered scalebar in a canvas.
+         * @returns {Element} A canvas containing the scalebar representation
+         */
+        getAsCanvas: function() {
+            var canvas = document.createElement("canvas");
+            canvas.width = this.divElt.offsetWidth;
+            canvas.height = this.divElt.offsetHeight;
+            var context = canvas.getContext("2d");
+            context.fillStyle = this.backgroundColor;
+            context.fillRect(0, 0, canvas.width, canvas.height);
+            context.fillStyle = this.color;
+            context.fillRect(0, canvas.height - this.barThickness,
+                    canvas.width, canvas.height);
+            if (this.drawScalebar === this.drawMapScalebar) {
+                context.fillRect(0, 0, this.barThickness, canvas.height);
+                context.fillRect(canvas.width - this.barThickness, 0,
+                        this.barThickness, canvas.height);
+            }
+            context.font = window.getComputedStyle(this.divElt).font;
+            context.textAlign = "center";
+            context.textBaseline = "middle";
+            context.fillStyle = this.fontColor;
+            var hCenter = canvas.width / 2;
+            var vCenter = canvas.height / 2;
+            context.fillText(this.divElt.textContent, hCenter, vCenter);
+            return canvas;
+        },
+        /**
+         * Get a copy of the current OpenSeadragon canvas with the scalebar.
+         * @returns {Element} A canvas containing a copy of the current OpenSeadragon canvas with the scalebar
+         */
+        getImageWithScalebarAsCanvas: function() {
+            var imgCanvas = this.viewer.drawer.canvas;
+            var newCanvas = document.createElement("canvas");
+            newCanvas.width = imgCanvas.width;
+            newCanvas.height = imgCanvas.height;
+            var newCtx = newCanvas.getContext("2d");
+            newCtx.drawImage(imgCanvas, 0, 0);
+            var scalebarCanvas = this.getAsCanvas();
+            var location = this.getScalebarLocation();
+            newCtx.drawImage(scalebarCanvas, location.x, location.y);
+            return newCanvas;
+        }
+    };
+
+    $.ScalebarSizeAndTextRenderer = {
+        /**
+         * Metric length. From nano meters to kilometers.
+         */
+        METRIC_LENGTH: function(ppm, minSize) {
+            return getScalebarSizeAndTextForMetric(ppm, minSize, "m");
+        },
+        /**
+         * Imperial length. Choosing the best unit from thou, inch, foot and mile.
+         */
+        IMPERIAL_LENGTH: function(ppm, minSize) {
+            var maxSize = minSize * 2;
+            var ppi = ppm * 0.0254;
+            if (maxSize < ppi * 12) {
+                if (maxSize < ppi) {
+                    var ppt = ppi / 1000;
+                    return getScalebarSizeAndText(ppt, minSize, "th");
+                }
+                return getScalebarSizeAndText(ppi, minSize, "in");
+            }
+            var ppf = ppi * 12;
+            if (maxSize < ppf * 2000) {
+                return getScalebarSizeAndText(ppf, minSize, "ft");
+            }
+            var ppmi = ppf * 5280;
+            return getScalebarSizeAndText(ppmi, minSize, "mi");
+        },
+        /**
+         * Astronomy units. Choosing the best unit from arcsec, arcminute, and degree
+         */
+        ASTRONOMY: function(ppa, minSize) {
+	    var maxSize = minSize * 2;
+            if (maxSize < ppa * 60) {
+                return getScalebarSizeAndText(ppa, minSize, "\"", false, '');
+            }
+            var ppminutes = ppa * 60;
+            if (maxSize < ppminutes * 60) {
+                return getScalebarSizeAndText(ppminutes, minSize, "\'", false, '');
+            }
+            var ppd = ppminutes * 60;
+            return getScalebarSizeAndText(ppd, minSize, "&#176", false, '');
+	},
+        /**
+         * Standard time. Choosing the best unit from second (and metric divisions),
+         * minute, hour, day and year.
+         */
+        STANDARD_TIME: function(pps, minSize) {
+            var maxSize = minSize * 2;
+            if (maxSize < pps * 60) {
+                return getScalebarSizeAndTextForMetric(pps, minSize, "s", false);
+            }
+            var ppminutes = pps * 60;
+            if (maxSize < ppminutes * 60) {
+                return getScalebarSizeAndText(ppminutes, minSize, "minute", true);
+            }
+            var pph = ppminutes * 60;
+            if (maxSize < pph * 24) {
+                return getScalebarSizeAndText(pph, minSize, "hour", true);
+            }
+            var ppd = pph * 24;
+            if (maxSize < ppd * 365.25) {
+                return getScalebarSizeAndText(ppd, minSize, "day", true);
+            }
+            var ppy = ppd * 365.25;
+            return getScalebarSizeAndText(ppy, minSize, "year", true);
+        },
+        /**
+         * Generic metric unit. One can use this function to create a new metric
+         * scale. For example, here is an implementation of energy levels:
+         * function(ppeV, minSize) {
+         *   return OpenSeadragon.ScalebarSizeAndTextRenderer.METRIC_GENERIC(
+         *           ppeV, minSize, "eV");
+         * }
+         */
+        METRIC_GENERIC: getScalebarSizeAndTextForMetric
+    };
+
+    // Missing TiledImage.viewportToImageZoom function in OSD 2.0.0
+    function tiledImageViewportToImageZoom(tiledImage, viewportZoom) {
+        var ratio = tiledImage._scaleSpring.current.value *
+                tiledImage.viewport._containerInnerSize.x /
+                tiledImage.source.dimensions.x;
+        return ratio * viewportZoom;
+    }
+
+    function getScalebarSizeAndText(ppm, minSize, unitSuffix, handlePlural, spacer) {
+	spacer = spacer === undefined ? ' ' : spacer;
+        var value = normalize(ppm, minSize);
+        var factor = roundSignificand(value / ppm * minSize, 3);
+        var size = value * minSize;
+        var plural = handlePlural && factor > 1 ? "s" : "";
+        return {
+            size: size,
+            text: factor + spacer + unitSuffix + plural
+        };
+    }
+
+    function getScalebarSizeAndTextForMetric(ppm, minSize, unitSuffix) {
+        var value = normalize(ppm, minSize);
+        var factor = roundSignificand(value / ppm * minSize, 3);
+        var size = value * minSize;
+        var valueWithUnit = getWithUnit(factor, unitSuffix);
+        return {
+            size: size,
+            text: valueWithUnit
+        };
+    }
+
+    function normalize(value, minSize) {
+        var significand = getSignificand(value);
+        var minSizeSign = getSignificand(minSize);
+        var result = getSignificand(significand / minSizeSign);
+        if (result >= 5) {
+            result /= 5;
+        }
+        if (result >= 4) {
+            result /= 4;
+        }
+        if (result >= 2) {
+            result /= 2;
+        }
+        return result;
+    }
+
+    function getSignificand(x) {
+        return x * Math.pow(10, Math.ceil(-log10(x)));
+    }
+
+    function roundSignificand(x, decimalPlaces) {
+        var exponent = -Math.ceil(-log10(x));
+        var power = decimalPlaces - exponent;
+        var significand = x * Math.pow(10, power);
+        // To avoid rounding problems, always work with integers
+        if (power < 0) {
+            return Math.round(significand) * Math.pow(10, -power);
+        }
+        return Math.round(significand) / Math.pow(10, power);
+    }
+
+    function log10(x) {
+        return Math.log(x) / Math.log(10);
+    }
+
+    function getWithUnit(value, unitSuffix) {
+        if (value < 0.000001) {
+            return value * 1000000000 + " n" + unitSuffix;
+        }
+        if (value < 0.001) {
+            return value * 1000000 + " μ" + unitSuffix;
+        }
+        if (value < 1) {
+            return value * 1000 + " m" + unitSuffix;
+        }
+        if (value >= 1000) {
+            return value / 1000 + " k" + unitSuffix;
+        }
+        return value + " " + unitSuffix;
+    }
+
+    function isDefined(variable) {
+        return typeof (variable) !== "undefined";
+    }
+}(OpenSeadragon));

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -97,8 +97,8 @@ const tmapp = (function() {
      */
     function _updateBrightnessContrast() {
         //const ctx=_viewer.drawer.context;
-        //Since I'm not 100% sure that Safari supports the above 
-        // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/filter 
+        //Since I'm not 100% sure that Safari supports the above
+        // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/filter
         //we use the css-style property instead
         const ctx=document.getElementById("ISS_viewer").querySelector('.openseadragon-canvas').style;
         if (_currState.contrast==0 && _currState.brightness==0) {
@@ -330,6 +330,9 @@ const tmapp = (function() {
             _updateBrightnessContrast();
             tmappUI.clearImageError();
             tmappUI.enableCollabCreation();
+            metadataHandler.updateMetadataValues({
+                resolution: viewer.world.getItemAt(0).getContentSize();
+            });
             callback && callback();
         });
 
@@ -599,7 +602,7 @@ const tmapp = (function() {
         setContrast(_currState.contrast+delta);
     }
 
-    
+
     /**
      * Get the name of the currently opened image.
      * @returns {string} The current image name.

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -695,7 +695,8 @@ const tmapp = (function() {
                 pixelsPerMeter: pixelsPerMeter,
                 type: OpenSeadragon.ScalebarType.MICROSCOPY,
                 location: OpenSeadragon.ScalebarLocation.BOTTOM_RIGHT,
-                backgroundColor: "rgba(255,255,255,0.5)"
+                backgroundColor: "rgba(255,255,255,0.5)",
+                stayInsideImage: false // Necessary for rotation to work
             });
         }
         else {

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -329,10 +329,6 @@ const tmapp = (function() {
             _updateRotation();
             _updateBrightnessContrast();
             tmappUI.clearImageError();
-            tmappUI.enableCollabCreation();
-            metadataHandler.updateMetadataValues({
-                resolution: viewer.world.getItemAt(0).getContentSize()
-            });
             callback && callback();
         });
 

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -692,8 +692,9 @@ const tmapp = (function() {
         if (_viewer) {
             _viewer.scalebar({
                 pixelsPerMeter: pixelsPerMeter,
-                type: "microscopy",
-                location: 3
+                type: OpenSeadragon.ScalebarType.MICROSCOPY,
+                location: OpenSeadragon.ScalebarLocation.BOTTOM_RIGHT,
+                backgroundColor: "rgba(255,255,255,0.5)"
             });
         }
         else {

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -683,6 +683,23 @@ const tmapp = (function() {
         _viewer.innerTracker.keyHandler(event);
     }
 
+    /**
+     * Update the scale of the scalebar.
+     * @param {number} pixelsPerMeter The number of pixels in one meter.
+     */
+    function updateScalebar(pixelsPerMeter) {
+        // Uses: https://github.com/usnistgov/OpenSeadragonScalebar
+        if (_viewer) {
+            _viewer.scalebar({
+                pixelsPerMeter: pixelsPerMeter,
+                type: "microscopy"
+            });
+        }
+        else {
+            throw new Error ("Tried to adjust scalebar without a viewer.");
+        }
+    }
+
     return {
         init: init,
         openImage: openImage,
@@ -705,6 +722,8 @@ const tmapp = (function() {
         disableControls: disableControls,
 
         keyHandler: keyHandler,
-        keyDownHandler: keyDownHandler
+        keyDownHandler: keyDownHandler,
+
+        updateScalebar: updateScalebar
     };
 })();

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -692,7 +692,8 @@ const tmapp = (function() {
         if (_viewer) {
             _viewer.scalebar({
                 pixelsPerMeter: pixelsPerMeter,
-                type: "microscopy"
+                type: "microscopy",
+                location: 3
             });
         }
         else {

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -331,7 +331,7 @@ const tmapp = (function() {
             tmappUI.clearImageError();
             tmappUI.enableCollabCreation();
             metadataHandler.updateMetadataValues({
-                resolution: viewer.world.getItemAt(0).getContentSize();
+                resolution: viewer.world.getItemAt(0).getContentSize()
             });
             callback && callback();
         });

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -368,6 +368,7 @@ const tmapp = (function() {
 
     function _clearCurrentImage() {
         annotationHandler.clear(false);
+        metadataHandler.clear();
         _viewer && _viewer.destroy();
         $("#ISS_viewer").empty();
         coordinateHelper.clearImage();

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -86,10 +86,10 @@ const tmappUI = (function(){
 
     function _initGlobalComments() {
         const container = $("#global_comments");
-        const inputFun = metadataHandler.sendCommentToServer;
-        const removeFun = metadataHandler.sendCommentRemovalToServer;
+        const inputFun = globalDataHandler.sendCommentToServer;
+        const removeFun = globalDataHandler.sendCommentRemovalToServer;
         const updateFun = htmlHelper.buildCommentSectionAlt(container, inputFun, removeFun);
-        metadataHandler.setCommentUpdateFun(updateFun);
+        globalDataHandler.setCommentUpdateFun(updateFun);
     }
 
     function _initClassSelectionButtons() {

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -85,6 +85,10 @@ const tmappUI = (function(){
     }
 
     function _initGlobalComments() {
+        // Make sure you can copy/paste things in the menu
+        $("#comments_collapse").keyup(e => e.ctrlKey && e.stopPropagation());
+        $("#comments_collapse").keydown(e => e.ctrlKey && e.stopPropagation());
+        $("#comments_collapse").keypress(e => e.ctrlKey && e.stopPropagation());
         const container = $("#global_comments");
         const inputFun = metadataHandler.sendCommentToServer;
         const removeFun = metadataHandler.sendCommentRemovalToServer;

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -85,10 +85,6 @@ const tmappUI = (function(){
     }
 
     function _initGlobalComments() {
-        // Make sure you can copy/paste things in the menu
-        $("#comments_collapse").keyup(e => e.ctrlKey && e.stopPropagation());
-        $("#comments_collapse").keydown(e => e.ctrlKey && e.stopPropagation());
-        $("#comments_collapse").keypress(e => e.ctrlKey && e.stopPropagation());
         const container = $("#global_comments");
         const inputFun = metadataHandler.sendCommentToServer;
         const removeFun = metadataHandler.sendCommentRemovalToServer;
@@ -198,6 +194,11 @@ const tmappUI = (function(){
         //1,2,... for class selection
         //z,x for focus up down
         $("#main_content").keydown(function(){
+            // Prevent the keyboard shortcuts from being used when the ctrl key is down
+            // This is just a simple way of letting people copy and paste, could be refined
+            if (event.ctrlKey) {
+                return;
+            }
             let caught=true; //Assume we use the key (setting to false in 'default')
             switch(event.keyCode) {
                 case 27: // esc

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -4,6 +4,8 @@
  * different users of the CytoBrowser.
  */
 
+const sanitize = require("sanitize-filename");
+
 // Modules initialized in export
 let autosave, metadata;
 
@@ -428,7 +430,8 @@ function getId() {
  * has an effect if the collaboration has not been created yet.
  */
 function joinCollab(ws, name, userId, id, image) {
-    const collab = getCollab(id, image);
+    const cleanImage = sanitize(image);
+    const collab = getCollab(id, cleanImage);
     collab.addMember(ws, name, userId);
 }
 
@@ -474,7 +477,8 @@ function handleMessage(ws, id, msg) {
  * image ids and their names.
  */
 function getAvailable(image) {
-    return autosave.getSavedIds(image);
+    const cleanImage = sanitize(image);
+    return autosave.getSavedIds(cleanImage);
 }
 
 module.exports = function(autosaveDir, metadataJsonDir) {

--- a/server/collaboration.js
+++ b/server/collaboration.js
@@ -4,8 +4,8 @@
  * different users of the CytoBrowser.
  */
 
-// Autosave module, initialized in export
-let autosave;
+// Modules initialized in export
+let autosave, metadata;
 
 // Object for storing all ongoing collaborations
 const collabs = {};
@@ -280,7 +280,8 @@ class Collaboration {
             image: this.image,
             members: Array.from(this.members.values()),
             annotations: this.annotations,
-            comments: this.comments
+            comments: this.comments,
+            metadata: metadata.getMetadataForImage(this.image)
         }
     }
 
@@ -476,8 +477,9 @@ function getAvailable(image) {
     return autosave.getSavedIds(image);
 }
 
-module.exports = function(dir) {
-    autosave = require("./autosave")(dir);
+module.exports = function(autosaveDir, metadataJsonDir) {
+    autosave = require("./autosave")(autosaveDir);
+    metadata = require("./metadata")(metadataJsonDir);
     return {
         getId: getId,
         joinCollab: joinCollab,

--- a/server/metadata.js
+++ b/server/metadata.js
@@ -55,9 +55,19 @@ function getMetadataForImage(imageName) {
     }
     else {
         const filename = `${adjustedImageName}.json`;
-        const data = JSON.parse(fs.readFileSync(`${jsonDir}/${filename}`));
-        metadataCache[adjustedImageName] = data;
-        return data;
+        try {
+            const data = JSON.parse(fs.readFileSync(`${jsonDir}/${filename}`));
+            metadataCache[adjustedImageName] = data;
+            return data;
+        }
+        catch (e) {
+            if (e.code === "ENOENT") {
+                return {};
+            }
+            else {
+                throw e;
+            }
+        }
     }
 }
 

--- a/server/metadata.js
+++ b/server/metadata.js
@@ -12,6 +12,7 @@ const parser = require("fast-xml-parser");
 
 
 const metadataCache = {};
+const metadataExpirationTime = 60000; // Let the cache expire after 30s
 let jsonDir;
 
 function xmlToObject(xmlData) {
@@ -58,6 +59,10 @@ function getMetadataForImage(imageName) {
         try {
             const data = JSON.parse(fs.readFileSync(`${jsonDir}/${filename}`));
             metadataCache[adjustedImageName] = data;
+            setTimeout(() =>
+                delete metadataCache[adjustedImageName],
+                metadataExpirationTime
+            );
             return data;
         }
         catch (e) {

--- a/server/metadata.js
+++ b/server/metadata.js
@@ -1,0 +1,78 @@
+const fs = require("fs");
+const parser = require("fast-xml-parser");
+
+
+const metadataCache = {};
+let jsonDir;
+
+function xmlToObject(xmlData) {
+    const options = {
+        attributeNamePrefix: "@_",
+        ignoreAttributes: false,
+        allowBooleanAttributes: true,
+        parseAttributeValue: true
+    };
+    return parser.parse(xmlData, options);
+}
+
+function extractImportantMetadata(jsonData) {
+    const imageData = jsonData["OME"]["Image"].find(im => im["@_ID"] === "Image:0");
+    const importantMetadata = {
+        MicroscopeModel: jsonData["OME"]["Instrument"]["Microscope"]["@_Model"],
+        NominalMagnification: jsonData["OME"]["Instrument"]["Objective"]["@_NominalMagnification"],
+        AcquisitionDate: imageData["AcquisitionDate"],
+        PhysicalSizeX: imageData["Pixels"]["@_PhysicalSizeX"],
+        PhysicalSizeY: imageData["Pixels"]["@_PhysicalSizeY"],
+        PhysicalSizeXUnit: imageData["Pixels"]["@_PhysicalSizeXUnit"],
+        PhysicalSizeYUnit: imageData["Pixels"]["@_PhysicalSizeYUnit"],
+        SignificantBits: imageData["Pixels"]["@_SignificantBits"],
+        SizeC: imageData["Pixels"]["@_SizeC"],
+        SizeX: imageData["Pixels"]["@_SizeX"],
+        SizeY: imageData["Pixels"]["@_SizeY"],
+        SizeZ: imageData["Pixels"]["@_SizeZ"],
+    };
+    return importantMetadata;
+}
+
+/**
+ * Get important metadata that corresponds to a specified image.
+ * @param {string} imageName The name of the image.
+ * @returns {Object} Relevant metadata for the image.
+ */
+function getMetadataForImage(imageName) {
+    const adjustedImageName = imageName.slice(0, -4);
+    if (metadataCache[adjustedImageName]) {
+        return metadataCache[adjustedImageName];
+    }
+    else {
+        const filename = `${adjustedImageName}.json`;
+        const data = JSON.parse(fs.readFileSync(`${jsonDir}/${filename}`));
+        metadataCache[adjustedImageName] = data;
+        return data;
+    }
+}
+
+function main() {
+    const inputDir = process.argv[2];
+    const outputDir = process.argv[3];
+    const inputFilenames = fs.readdirSync(inputDir).filter(fn => fn.endsWith(".ome.xml"));
+    inputFilenames.forEach(fn => {
+        const path = `${inputDir}/${fn}`;
+        const outputFilename = `${fn.slice(0, -8)}.json`;
+        const outputPath = `${outputDir}/${outputFilename}`;
+        const xmlData = fs.readFileSync(path, "utf8");
+        const data = xmlToObject(xmlData);
+        const importantData = extractImportantMetadata(data);
+        fs.writeFileSync(outputPath, JSON.stringify(importantData, null, 4));
+    });
+}
+
+module.exports = function() {
+    return {
+        getMetadataForImage: getMetadataForImage
+    }
+};
+
+if (require.main === module) {
+    main();
+}

--- a/server/metadata.js
+++ b/server/metadata.js
@@ -63,8 +63,8 @@ function getMetadataForImage(imageName) {
 
 function main() {
     const argv = require("minimist")(process.argv.slice(2));
-    if (argv.h || argv.help || ) {
-        console.info("node metadata.js omexml-dir json-dir");
+    if (argv.h || argv.help || argv._.length !== 2) {
+        console.info("Usage: node metadata.js omexml-dir json-dir");
         return;
     }
     else {

--- a/server/metadata.js
+++ b/server/metadata.js
@@ -1,3 +1,12 @@
+/**
+ * @module metadata
+ * @desc Module for handling metadata on the server. This module both
+ * contains logic for the server's handling of metadata and for preparation
+ * of abridged JSON-formatted metadata from OME-XML files. This second
+ * functionality can be used by calling the module itself as the point
+ * of entry.
+ */
+
 const fs = require("fs");
 const parser = require("fast-xml-parser");
 
@@ -53,18 +62,25 @@ function getMetadataForImage(imageName) {
 }
 
 function main() {
-    const inputDir = process.argv[2];
-    const outputDir = process.argv[3];
-    const inputFilenames = fs.readdirSync(inputDir).filter(fn => fn.endsWith(".ome.xml"));
-    inputFilenames.forEach(fn => {
-        const path = `${inputDir}/${fn}`;
-        const outputFilename = `${fn.slice(0, -8)}.json`;
-        const outputPath = `${outputDir}/${outputFilename}`;
-        const xmlData = fs.readFileSync(path, "utf8");
-        const data = xmlToObject(xmlData);
-        const importantData = extractImportantMetadata(data);
-        fs.writeFileSync(outputPath, JSON.stringify(importantData, null, 4));
-    });
+    const argv = require("minimist")(process.argv.slice(2));
+    if (argv.h || argv.help || ) {
+        console.info("node metadata.js omexml-dir json-dir");
+        return;
+    }
+    else {
+        const inputDir = argv._[0];
+        const outputDir = argv._[1];
+        const inputFilenames = fs.readdirSync(inputDir).filter(fn => fn.endsWith(".ome.xml"));
+        inputFilenames.forEach(fn => {
+            const path = `${inputDir}/${fn}`;
+            const outputFilename = `${fn.slice(0, -8)}.json`;
+            const outputPath = `${outputDir}/${outputFilename}`;
+            const xmlData = fs.readFileSync(path, "utf8");
+            const data = xmlToObject(xmlData);
+            const importantData = extractImportantMetadata(data);
+            fs.writeFileSync(outputPath, JSON.stringify(importantData, null, 4));
+        });
+    }
 }
 
 module.exports = function(dir) {

--- a/server/metadata.js
+++ b/server/metadata.js
@@ -67,7 +67,8 @@ function main() {
     });
 }
 
-module.exports = function() {
+module.exports = function(dir) {
+    jsonDir = dir;
     return {
         getMetadataForImage: getMetadataForImage
     }


### PR DESCRIPTION
Pull request for issues #118 and #110. Inclusion of metadata that can be viewed in CytoBrowser under the `Global Data` tab, as well as a scalebar in the OpenSeadragon window. For a given image, the metadata has to be prepared as follows:

1. Extract the metadata from the microscopy images (I used `.ndpi` files) using bftools and write them to OME-XML files in a separate directory: `bftools/showinf -nocore -no-sas -nopix -omexml -omexml-only [filename].ndpi > [OME-XML directory]/[filename].ome.xml`
2. Use the `metadata` module to convert the OME-XML files to JSON and store the JSON files in a separate directory: `node server/metadata.js [OME-XML directory] [JSON directory]`
3. If the JSON directory is not the default directory `metadata/json`, specify the path to the JSON directory when starting the server: `node cytobrowser.js [hostname] [port] -m [JSON directory]`

I included the metadata values that I thought would be relevant in the JSON files, but there may be more values of interest in the original OME-XML files. This can be adjusted in the `extractImportantMetadata()` function of `server/metadata.js`. I also make the assumption that the files use the same naming pattern as in the dataset I'm working with, where the `.ndpi` files have the same name as the images but without `_x40` at the end, but this could also be adjusted.

In order to reduce the number of reads from secondary storage, this includes a simple caching system that stores the metadata for a given image for 60 seconds before reading from storage again. It may therefore take a minute to see any changes if the metadata files are changed while running CytoBrowser.