### PR TITLE
Issue/47 smart load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -585,6 +585,7 @@
 <script src="js/bootstrap/bootstrap.4.0.0.bundle.min.js" ></script>
 <script src="js/bootstrap/bootstrap-slider.min.js" ></script>
 <script src="js/openseadragon/openseadragon.2.4.0.min.js"></script>
+<script src="js/openseadragon/openseadragon-focus-levels.js"></script>
 <script src="js/openseadragon/openseadragon-viewerinputhook.js"></script>
 <!-- <script src="js/openseadragon/openseadragon-filtering.js"></script> -->
 <script src="js/openseadragon/openseadragon-svg-overlay.js"></script>

--- a/public/js/openseadragon/openseadragon-focus-levels.js
+++ b/public/js/openseadragon/openseadragon-focus-levels.js
@@ -220,12 +220,12 @@
             }
             const index = viewer.world.getIndexOfItem(this);
             if (index === 0) {
-                this._unalteredDraw();
+                return this._unalteredDraw();
             }
             else {
                 const previousTile = viewer.world.getItemAt(index - 1);
                 if (previousTile.getFullyLoaded()) {
-                    this._unalteredDraw();
+                    return this._unalteredDraw();
                 }
                 else {
                     this._awaitingDrawCall = true;
@@ -237,7 +237,7 @@
             }
         }
         else {
-            this._unalteredDraw();
+            return this._unalteredDraw();
         }
     }
 
@@ -254,9 +254,11 @@
                 this._matchOpacity(item, original);
                 this._matchCompositeOperation(item, original);
             };
+            options.success = newSuccess;
+            return $.Viewer.prototype._unalteredAddTiledImage(this, [options]);
         }
         else {
-            this._unalteredAddTiledImage(options);
+            return this._unalteredAddTiledImage(options);
         }
     }
 })(OpenSeadragon);

--- a/public/js/openseadragon/openseadragon-focus-levels.js
+++ b/public/js/openseadragon/openseadragon-focus-levels.js
@@ -1,3 +1,12 @@
+/**
+ * Small plugin used for handling the focus adjustment in OpenSeadragon.
+ * Moved to here in order to keep the other code a bit simpler, and could
+ * potentially also be used in other projects that require focus adjustment
+ * in OSD. The plugin extends the Viewer class by adding the function
+ * openFocusLevels(), which sets an array of images up as focus levels
+ * that can be swapped between using setFocusLevel(), decrementFocus(),
+ * and incrementFocus().
+ */
 (function($) {
     "use strict";
 
@@ -33,10 +42,22 @@
     }
 
     /**
-     * TODO
+     * Open a series of images that together form a stack of the same
+     * subject at different focus levels. This function prepares the
+     * images in such a way that the focus level can be changed, with
+     * this being implemented through a change in opacity.
+     * @param {Array<>} tileSources An array of tile sources for the
+     * images that represent the different focus levels of the subject.
+     * @param {number} [initialZ] The z level that should be set as the
+     * initial focus level in the OSD viewer. If not set, it will
+     * automatically be set to the first z level.
+     * @param {Array<number>} [zLevels] The z levels that the array of
+     * tile sources correspond to, which are used as values when setting
+     * the focus later on. If not set, it will automatically be set to
+     * represent the indices of the tile sources.
      */
     $.Viewer.prototype.openFocusLevels = function(tileSources, initialZ, zLevels) {
-        // TODO: What to do about OSD sequence mode?
+        // TODO: Not used in CyBr, but what to do about OSD sequence mode?
 
         if (!Array.isArray(tileSources)) {
             tileSources = [tileSources];
@@ -102,7 +123,11 @@
     }
 
     /**
-     * TODO
+     * Set the focus level of the of the OSD viewer, assuming the images
+     * were opened using openFocusLevels().
+     * @param {number} z The new focus level. The value used should
+     * correspond to the value specified in the zLevels argument of
+     * openFocusLevels().
      */
     $.Viewer.prototype.setFocusLevel = function(z) {
         const oldZ = this._currentZ;
@@ -138,6 +163,10 @@
         }
     }
 
+    /**
+     * Increment the focus level of the viewer if possible.
+     * @returns {number} The new focus level.
+     */
     $.Viewer.prototype.incrementFocus = function() {
         const nItems = this._nFocusLevels;
         const oldZ = this._currentZ;
@@ -153,6 +182,10 @@
         }
     }
 
+    /**
+     * Decrement the focus level of the viewer if possible.
+     * @returns {number} The new focus level.
+     */
     $.Viewer.prototype.decrementFocus = function() {
         const oldZ = this._currentZ;
         const oldZIndex = this._zLevels.findIndex(z => oldZ === z);

--- a/public/js/openseadragon/openseadragon-focus-levels.js
+++ b/public/js/openseadragon/openseadragon-focus-levels.js
@@ -1,0 +1,116 @@
+(function($) {
+    "use strict";
+
+    // Ensure OSD exists
+    if (!$) {
+        $ = require("openseadragon");
+        if (!$) {
+            throw new Error("OpenSeadragon is missing.");
+        }
+    }
+
+    /**
+     * Utility function for getting the best load order of slides for a
+     * given focus level. The order will be the one that first loads the
+     * current focus level, followed by the focus level closest to the
+     * current level. The function favors higher focus levels, such that
+     * _getLoadOrder(5, 2) will give [2, 3, 1, 4, 0].
+     * @param {number} n The number of focus levels.
+     * @param {number} z The current focus level.
+     * @returns {Array<number>} The ideal order in which to load focus levels.
+     */
+    function _getLoadOrder(n, z) {
+        const order = [z];
+        for (let d = 1; d < n; d++) {
+            if (z + d < n) {
+                order.push(z + d);
+            }
+            if (z - d >= 0) {
+                order.push(z - d);
+            }
+        }
+        return order;
+    }
+
+    /**
+     * TODO
+     */
+    $.Viewer.prototype.openFocusLevels = function(tileSources, initialZ) {
+        // TODO: What to do about OSD sequence mode?
+
+        if (!Array.isArray(tileSources)) {
+            tileSources = [tileSources];
+        }
+        const nLevels = tileSources.length;
+
+        // Set an initial focus level if none has been set
+        if (initialZ !== "number" || initialZ < 0) {
+            console.warn("Invalid initial focus level, setting to 0.");
+            initialZ = 0;
+        }
+        else if (initialZ >= nLevels) {
+            console.warn("Invalid initial focus level, setting to max.");
+            initialZ = nLevels - 1;
+        }
+
+        // Set appropriate opacities for all tile sources
+        const tileSourcesWithOpacity = tileSources.map((tileSource, z) => {
+            if (typeof tileSource === "string") {
+                return {
+                    tileSource: tileSource,
+                    opacity: z === initialZ ? 1 : 0
+                };
+            }
+            else if (typeof tileSource === "object") {
+                tileSource.opacity = z === initialZ ? 1 : 0;
+                return tileSource;
+            }
+        });
+
+        // Reorder the tile sources
+        const order = _getLoadOrder(nLevels, initialZ);
+        const orderedTileSources = order.map(z => {
+            return tileSourcesWithOpacity[z];
+        });
+
+        this._hasFocusLevels = true;
+        this._currentLoadOrder = order;
+        this._nFocusLevels = nLevels;
+        this._currentZ = initialZ;
+        this.open(orderedTileSources);
+    }
+
+    /**
+     * TODO
+     */
+    $.Viewer.prototype.setFocusLevel = function(z) {
+        const oldZ = this._currentZ;
+        const newZ = z;
+        const nItems = this.world._items.length;
+
+        if (!this._hasFocusLevels) {
+            throw new Error("Cannot set focus level if tiles were not initialized as focus levels.");
+        }
+
+        if (z < 0 || z >= nItems) {
+            throw new Error("Cannot set a focus level outside the range of focus levels.");
+        }
+
+        if (oldZ !== newZ) {
+            // Rearrange the load order of the items
+            const oldOrder = this._currentLoadOrder;
+            const newOrder = _getLoadOrder(n, newZ);
+            const unorderedItems = new Array(nItems);
+            oldOrder.forEach((z, i) => unorderedItems[z] = this.world._items[i]);
+            this.world._items.length = 0;
+            newOrder.forEach(z => this.world._items.push(unorderedItems[z]));
+
+            // Adjust the opacities
+            unorderedItems[newZ].setOpacity(1);
+            unorderedItems[oldZ].setOpacity(0);
+
+            // Set the current order for the next focus level change
+            this._currentLoadOrder = newOrder;
+        }
+    }
+})(OpenSeadragon);

--- a/public/js/openseadragon/openseadragon-focus-levels.js
+++ b/public/js/openseadragon/openseadragon-focus-levels.js
@@ -205,6 +205,9 @@
     $.TiledImage.prototype.draw = function() {
         const viewer = this.viewer;
         if (viewer._hasFocusLevels) {
+            if (this._awaitingDrawCall) {
+                return;
+            }
             const index = viewer.world.getIndexOfItem(this);
             if (index === 0) {
                 this._unalteredDraw();
@@ -215,7 +218,9 @@
                     this._unalteredDraw();
                 }
                 else {
+                    this._awaitingDrawCall = true;
                     previousTile.addOnceHandler("fully-loaded-change", e => {
+                        this._awaitingDrawCall = false;
                         this.draw();
                     });
                 }

--- a/public/js/openseadragon/openseadragon-focus-levels.js
+++ b/public/js/openseadragon/openseadragon-focus-levels.js
@@ -88,7 +88,17 @@
         this._nFocusLevels = nLevels;
         this._currentZ = initialZ;
         this._zLevels = zLevels;
-        this.open(orderedTileSources); // TODO: Should raise event if any fail
+        orderedTileSources.forEach(tileSource => {
+            Object.assign(tileSource, {
+                success: () => {
+                    if (this.world.getItemCount() === nLevels) {
+                        this.raiseEvent("open");
+                    }
+                },
+                error: () => this.raiseEvent("open-failed")
+            });
+            this.addTiledImage(tileSource);
+        });
     }
 
     /**

--- a/public/js/openseadragon/openseadragon-focus-levels.js
+++ b/public/js/openseadragon/openseadragon-focus-levels.js
@@ -44,7 +44,7 @@
         const nLevels = tileSources.length;
 
         // Set an initial focus level if none has been set
-        if (initialZ !== "number" || initialZ < 0) {
+        if (typeof initialZ !== "number" || initialZ < 0) {
             console.warn("Invalid initial focus level, setting to 0.");
             initialZ = 0;
         }
@@ -99,7 +99,7 @@
         if (oldZ !== newZ) {
             // Rearrange the load order of the items
             const oldOrder = this._currentLoadOrder;
-            const newOrder = _getLoadOrder(n, newZ);
+            const newOrder = _getLoadOrder(nItems, newZ);
             const unorderedItems = new Array(nItems);
             oldOrder.forEach((z, i) => unorderedItems[z] = this.world._items[i]);
             this.world._items.length = 0;
@@ -111,6 +111,32 @@
 
             // Set the current order for the next focus level change
             this._currentLoadOrder = newOrder;
+            this._currentZ = newZ;
+        }
+    }
+
+    $.Viewer.prototype.incrementFocusLevel = function() {
+        const nItems = this.world._items.length;
+        const oldZ = this._currentZ;
+        if (oldZ < nItems - 1) {
+            const newZ = oldZ + 1;
+            this.setFocusLevel(newZ);
+            return newZ;
+        }
+        else {
+            return oldZ;
+        }
+    }
+
+    $.Viewer.prototype.decrementFocusLevel = function() {
+        const oldZ = this._currentZ;
+        if (oldZ > 0) {
+            const newZ = oldZ - 1;
+            this.setFocusLevel(newZ);
+            return newZ;
+        }
+        else {
+            return oldZ;
         }
     }
 })(OpenSeadragon);

--- a/public/js/openseadragon/openseadragon-focus-levels.js
+++ b/public/js/openseadragon/openseadragon-focus-levels.js
@@ -160,6 +160,16 @@
             // Set the current order for the next focus level change
             this._currentLoadOrder = newOrder;
             this._currentZ = newZ;
+
+            // Make sure everything gets drawn properly
+            for (let i = 0; i < nItems; i++) {
+                const item = this.world.getItemAt(i);
+                const fullyLoaded = item.getFullyLoaded();
+                item.raiseEvent("fully-loaded-change", {
+                    fullyLoaded: fullyLoaded,
+                    eventSource: item
+                });
+            }
         }
     }
 

--- a/public/js/openseadragon/openseadragon-focus-levels.js
+++ b/public/js/openseadragon/openseadragon-focus-levels.js
@@ -255,7 +255,7 @@
                 this._matchCompositeOperation(item, original);
             };
             options.success = newSuccess;
-            return $.Viewer.prototype._unalteredAddTiledImage(this, [options]);
+            return $.Viewer.prototype._unalteredAddTiledImage.apply(this, [options]);
         }
         else {
             return this._unalteredAddTiledImage(options);

--- a/public/js/openseadragon/openseadragon-focus-levels.js
+++ b/public/js/openseadragon/openseadragon-focus-levels.js
@@ -41,6 +41,15 @@
         return order;
     }
 
+    function _alterLoadOrder(arr, oldOrder, newOrder) {
+        const oldOrder = this._currentLoadOrder;
+        const newOrder = _getLoadOrder(nItems, newZIndex);
+        const unorderedItems = new Array(nItems);
+        oldOrder.forEach((z, i) => unorderedItems[z] = arr[i]);
+        arr.length = 0;
+        newOrder.forEach(z => arr.push(unorderedItems[z]));
+    }
+
     /**
      * Open a series of images that together form a stack of the same
      * subject at different focus levels. This function prepares the
@@ -120,6 +129,32 @@
             });
             this.addTiledImage(tileSource);
         });
+
+        // Code necessary to fix bug in OSD navigator
+        // Can be fixed in the OSD source, the following can be removed if it is
+        if (this.navigator) {
+            const waitForNavigator = function() {
+                let nNavigatorItems = this.navigator.world.getItemCount();
+                if (nNavigatorItems < nItems) {
+                    this.navigator.world.addOnceHandler("add-item", waitForNavigator);
+                }
+                else {
+                    for (let i = 0; i < nItems; i++) {
+                        const item = this.world.getItemAt(i);
+                        const navItem = this.navigator.world.getItemAt(i);
+                        if (navItem.getFullyLoaded()) {
+                            navItem.setOpacity(item.getOpacity());
+                        }
+                        else {
+                            navItem.addOnceHandler("fully-loaded-change", e => {
+                                navItem.setOpacity(item.getOpacity());
+                            });
+                        }
+                    }
+                }
+            }
+            waitForNavigator();
+        }
     }
 
     /**
@@ -149,9 +184,10 @@
             const oldOrder = this._currentLoadOrder;
             const newOrder = _getLoadOrder(nItems, newZIndex);
             const unorderedItems = new Array(nItems);
-            oldOrder.forEach((z, i) => unorderedItems[z] = this.world._items[i]);
-            this.world._items.length = 0;
-            newOrder.forEach(z => this.world._items.push(unorderedItems[z]));
+            _alterLoadOrder(this.world._items, oldOrder, newOrder);
+            if (this.navigator) {
+                _alterLoadOrder(this.navigator.world._items, oldOrder, newOrder);
+            }
 
             // Adjust the opacities
             unorderedItems[newZIndex].setOpacity(1);

--- a/public/js/openseadragon/openseadragon-focus-levels.js
+++ b/public/js/openseadragon/openseadragon-focus-levels.js
@@ -46,7 +46,7 @@
      * subject at different focus levels. This function prepares the
      * images in such a way that the focus level can be changed, with
      * this being implemented through a change in opacity.
-     * @param {Array<>} tileSources An array of tile sources for the
+     * @param {Array} tileSources An array of tile sources for the
      * images that represent the different focus levels of the subject.
      * @param {number} [initialZ] The z level that should be set as the
      * initial focus level in the OSD viewer. If not set, it will

--- a/public/js/openseadragon/openseadragon-focus-levels.js
+++ b/public/js/openseadragon/openseadragon-focus-levels.js
@@ -199,4 +199,30 @@
             return oldZ;
         }
     }
+
+    // Wrapper of the draw function to force current focus level first
+    $.TiledImage.prototype._unalteredDraw = $.TiledImage.prototype.draw;
+    $.TiledImage.prototype.draw = function() {
+        const viewer = this.viewer;
+        if (viewer._hasFocusLevels) {
+            const index = viewer.world.getIndexOfItem(this);
+            if (index === 0) {
+                this._unalteredDraw();
+            }
+            else {
+                const previousTile = viewer.world.getItemAt(index - 1);
+                if (previousTile.getFullyLoaded()) {
+                    this._unalteredDraw();
+                }
+                else {
+                    previousTile.addOnceHandler("fully-loaded-change", e => {
+                        this.draw();
+                    });
+                }
+            }
+        }
+        else {
+            this._unalteredDraw();
+        }
+    }
 })(OpenSeadragon);

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -173,7 +173,7 @@ const tmapp = (function() {
         // Get the full image names based on the data from the server
         const imageName = _currentImage.name;
         const zLevels = _currentImage.zLevels;
-        const imageStack = zLevels.map(z => {
+        const imageStack = zLevels.map(zLevel => {
             return `${_imageDir}${imageName}_z${zLevel}.dzi`;
         });
         return imageStack;
@@ -184,8 +184,8 @@ const tmapp = (function() {
         const offset = Math.floor(imageStack.length / 2);
         const zLevels = Array.from({length: imageStack.length}, (x, i) => i - offset);
         console.info(`Opening: ${imageStack}`);
-        this._viewer.openFocusLevels(imageStack, 0, zLevels);
-        _currState.z = z;
+        _viewer.openFocusLevels(imageStack, initialZ, zLevels);
+        _currState.z = initialZ;
     }
 
     /**


### PR DESCRIPTION
Pull request for issue #47 . This prioritizes loading the current focus level first, followed by its surrounding focus levels, and makes changing the focus level from the rest of the code a bit simpler. I wrote the `openseadragon-focus-levels.js` plugin to deal with this, which also contains a small fix for a bug that would sometimes make the navigator invisible.