### PR TITLE
Issue/42 filter class

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -228,7 +228,7 @@
                     </div>
 
                     <!-- Import/Export -->
-                    <div class="card-body px-2">
+                    <div class="card-body px-2 pb-0">
                         <div class="row pb-1 pt-2">
                             <div class="col-3">
                                 <input class="d-none" type="file" id="data_files_import" onclick="this.value=null;" name="files[]">
@@ -250,7 +250,7 @@
                                 <div class="input-group">
                                     <input id="filter-query-input" type="text" class="form-control" placeholder="Filter annotations">
                                     <div class="input-group-append">
-                                        <button class="btn btn-info" data-toggle="modal" data-target="#filter-usage">Help</button>
+                                        <button class="btn btn-info" data-toggle="modal" data-target="#filter-usage" style="border-top-right-radius: 0.25rem;border-bottom-right-radius: 0.25rem;">Help</button>
                                     </div>
                                     <div id="filter-query-error" class="invalid-feedback">
                                     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -588,6 +588,7 @@
 <script src="js/fileBrowserUI.js"></script>
 <script src="js/tmappUI.js"></script>
 <script src="js/tmapp.js"></script>
+<script src="js/filters.js"></script>
 <script src="js/annotationVisuals.js"></script>
 <script src="js/annotationStorageConversion.js"></script>
 <script src="js/coordinateHelper.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -532,7 +532,6 @@
             </button>
           </div>
           <div class="modal-body p-4">
-              <h5>Session</h5>
               <p>
                   A filter can be used to specify which annotations
                   are shown in the viewport and annotation list. Filters
@@ -596,9 +595,9 @@
                     can be specified:
                 </p>
                 <ul>
-                    <li><code>NOT author &equals; "Bob"</code> &#8211; Annotations made by people other than Bob.</li>
                     <li><code>class &equals; "HSIL"</code> &#8211; Annotations belonging to the HSIL class.</li>
                     <li><code>x &gt; 50000</code> &#8211; Annotations with an x position greater than 50000.</li>
+                    <li><code>NOT author &equals; "Bob"</code> &#8211; Annotations made by people other than Bob.</li>
                     <li><code>author &equals; "Bob" AND bookmarked &equals; true</code> &#8211; Bookmarked annotations made by Bob.</li>
                     <li><code>bookmarked &equals; true OR comments &gt; 0</code> &#8211; Annotations that have either been bookmarked or commented on.</li>
                     <li><code>bookmarked &equals; true AND (class &equals; "Other" OR comments &gt; 0)</code> &#8211; Bookmarked annotations that either have the class "Other" or have been commented on.</li>

--- a/public/index.html
+++ b/public/index.html
@@ -521,7 +521,8 @@
       </div>
     </div> <!-- End of instructions -->
 
-    <div class="modal fade" id="instructions" tabindex="-1" role="dialog">
+    <!-- Filter instructions -->
+    <div class="modal fade" id="filter-usage" tabindex="-1" role="dialog">
       <div class="modal-dialog modal-xl" role="document">
         <div class="modal-content">
           <div class="modal-header">
@@ -606,7 +607,7 @@
           </div>
         </div>
       </div>
-    </div> <!-- End of instructions -->
+  </div> <!-- End of filter instructions -->
 
     <!-- Collaboration menu -->
     <div class="modal fade" id="collaboration_menu" tabindex="-1" role="dialog">

--- a/public/index.html
+++ b/public/index.html
@@ -250,7 +250,7 @@
                                 <div class="input-group">
                                     <input id="filter-query-input" type="text" class="form-control" placeholder="Filter annotations">
                                     <div class="input-group-append">
-                                        <button class="btn btn-info">Help</button>
+                                        <button class="btn btn-info" data-toggle="modal" data-target="#filter-usage">Help</button>
                                     </div>
                                     <div id="filter-query-error" class="invalid-feedback">
                                     </div>
@@ -516,6 +516,93 @@
                   you will only overwrite the latest version. When loading
                   a file, you can select which version of the file to load.
               </p>
+          </div>
+        </div>
+      </div>
+    </div> <!-- End of instructions -->
+
+    <div class="modal fade" id="instructions" tabindex="-1" role="dialog">
+      <div class="modal-dialog modal-xl" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Filtering annotations</h5>
+            <button type="button" class="close" data-dismiss="modal">
+              <span>&times;</span>
+            </button>
+          </div>
+          <div class="modal-body p-4">
+              <h5>Session</h5>
+              <p>
+                  A filter can be used to specify which annotations
+                  are shown in the viewport and annotation list. Filters
+                  can be specified through a combination of keys, values,
+                  comparisons, and combinations.
+              </p>
+              <h5>Keys</h5>
+                <p>
+                    Keys specify the properties of the annotations that
+                    should be considered when filtering the annotations.
+                    The available keys are:
+                </p>
+                <ul>
+                    <li><code>class</code> &#8211; The class the annotation belongs to.</li>
+                    <li><code>author</code> &#8211; The name of the user who created the annotation.</li>
+                    <li><code>comments</code> &#8211; The number of comments an annotation has.</li>
+                    <li><code>bookmarked</code> &#8211; Whether or not an annotation is bookmarked.</li>
+                    <li><code>region</code> &#8211; Whether or not an annotation is a region.</li>
+                    <li><code>marker</code> &#8211; Whether or not an annotation is a marker.</li>
+                    <li><code>x</code> &#8211; The x position of the annotation's centroid.</li>
+                    <li><code>y</code> &#8211; The y position of the annotation's centroid.</li>
+                    <li><code>z</code> &#8211; The z position of the annotation.</li>
+                </ul>
+              <h5>Values</h5>
+                <p>
+                    Values specify what the annotation properties should
+                    be compared to in the filter. A value can be a boolean,
+                    in which case it is specified as <code>true</code> or
+                    <code>false</code>, a string, in which case a quotation
+                    mark should be placed on either side of the value, or
+                    a number, which can be either an integer or a real number.
+                    In addition, the value can be specified as a key, in
+                    which case two properties of the annotation are compared
+                    to each other.
+                </p>
+              <h5>Comparisons</h5>
+                <p>
+                    Comparisons specify the relationships between keys
+                    and values that should be fulfilled for an annotation
+                    to pass a filter. The available comparisons are:
+                </p>
+                <ul>
+                    <li><code>[key] &equals; [value]</code> &#8211; A key is exactly equal to a given value.</li>
+                    <li><code>[key] &gt; [value]</code> &#8211; A key is greater than a given value.</li>
+                    <li><code>[key] &lt; [value]</code> &#8211; A key is less than a given value.</li>
+                </ul>
+              <h5>Combinations</h5>
+                <p>
+                    Combinations are used to combine or modify smaller
+                    parts of the filter.  The available combinations are:
+                </p>
+                <ul>
+                    <li><code>[subfilter] AND [subfilter]</code> &#8211; Both subfilters must pass.</li>
+                    <li><code>[subfilter] OR [subfilter]</code> &#8211; One of the subfilters must pass.</li>
+                    <li><code>NOT [subfilter]</code> &#8211; The result of the subfilter is negated.</li>
+                    <li><code>([subfilter])</code> &#8211; The subfilter is evaluated in isolation.</li>
+                </ul>
+              <h5>Examples</h5>
+                <p>
+                    The following examples show some of the filters that
+                    can be specified:
+                </p>
+                <ul>
+                    <li><code>NOT author &equals; "Bob"</code> &#8211; Annotations made by people other than Bob.</li>
+                    <li><code>class &equals; "HSIL"</code> &#8211; Annotations belonging to the HSIL class.</li>
+                    <li><code>x &gt; 50000</code> &#8211; Annotations with an x position greater than 50000.</li>
+                    <li><code>author &equals; "Bob" AND bookmarked &equals; true</code> &#8211; Bookmarked annotations made by Bob.</li>
+                    <li><code>bookmarked &equals; true OR comments &gt; 0</code> &#8211; Annotations that have either been bookmarked or commented on.</li>
+                    <li><code>bookmarked &equals; true AND (class &equals; "Other" OR comments &gt; 0)</code> &#8211; Bookmarked annotations that either have the class "Other" or have been commented on.</li>
+                    <li><code>x &gt; y</code> &#8211; Annotations where the x position is greater than the y position.</li>
+                </ul>
           </div>
         </div>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -243,6 +243,20 @@
                         </div>
                     </div>
 
+                    <!-- Annotation filter -->
+                    <div class="card-body px-2">
+                        <div class="row">
+                            <div class="col">
+                                <div class="input-group">
+                                    <input type="text" class="form-control" placeholder="Filter annotations">
+                                    <div class="input-group-append">
+                                        <button class="btn btn-secondary">?</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- List of annotations -->
                     <table id="annotation-list" class="table table-striped table-hover text-center mb-0 mr-1">
                     </table>

--- a/public/index.html
+++ b/public/index.html
@@ -248,9 +248,13 @@
                         <div class="row">
                             <div class="col">
                                 <div class="input-group">
-                                    <input type="text" class="form-control" placeholder="Filter annotations">
+                                    <input id="filter-query-input" type="text" class="form-control" placeholder="Filter annotations">
                                     <div class="input-group-append">
-                                        <button class="btn btn-secondary">?</button>
+                                        <button class="btn btn-info">Help</button>
+                                    </div>
+                                    <div id="filter-query-error" class="invalid-feedback">
+                                    </div>
+                                    <div id="filter-query-info" class="valid-feedback">
                                     </div>
                                 </div>
                             </div>

--- a/public/js/annotationVisuals.js
+++ b/public/js/annotationVisuals.js
@@ -27,6 +27,19 @@ const annotationVisuals = (function() {
         }
     }
 
+    function _setFilter(query) {
+        try {
+            const filter = filters.getFilterFromQuery(query);
+            _filter = filter;
+        }
+        catch (e) {
+            const error = e.message;
+            tmappUI.setFilterError(error);
+            return;
+        }
+        _filterIsTrivial = query.length === 0;
+    }
+
     /**
      * Set the annotation list object that should be used to disply
      * information about the annotations. This should be set before
@@ -44,17 +57,22 @@ const annotationVisuals = (function() {
      * the same format as in filters.getFilterFromQuery().
      */
     function setFilterQuery(query) {
-        try {
-            const filter = filters.getFilterFromQuery(query);
-            _filter = filter;
-        }
-        catch (e) {
-            const error = e.message;
-            tmappUI.setFilterError(error);
-            return;
-        }
-        _filterIsTrivial = query.length === 0;
+        _setFilter(query);
         _filterAndUpdate();
+        if (_filterIsTrivial) {
+            tmappUI.clearFilterInfo();
+        }
+    }
+
+    /**
+     * Set the filter query without attempting to update the visuals.
+     * This can be called when the visuals are being initialized to
+     * avoid trying to draw on an overlay that doesn't exist.
+     * @param {string} query The filter query to be used. Should have
+     * the same format as in filters.getFilterFromQuery().
+     */
+    function setFilterQueryWithoutUpdating(query) {
+        _setFilter(query);
         if (_filterIsTrivial) {
             tmappUI.clearFilterInfo();
         }
@@ -87,6 +105,7 @@ const annotationVisuals = (function() {
         update: update,
         setAnnotationList: setAnnotationList,
         setFilterQuery: setFilterQuery,
+        setFilterQueryWithoutUpdating: setFilterQueryWithoutUpdating,
         clear: clear
     };
 })();

--- a/public/js/annotationVisuals.js
+++ b/public/js/annotationVisuals.js
@@ -15,17 +15,15 @@ const annotationVisuals = (function() {
             const filterableAnnotation = filters.preprocessDatumBeforeFiltering(annotation);
             return _filter.evaluate(filterableAnnotation);
         });
-        if (overlayHandler) {
-            overlayHandler.updateAnnotations(annotations);
-            if (_annotationList) {
-                _annotationList.updateData(annotations);
-            }
-            else {
-                console.warn("No annotation list has been set.");
-            }
-            if (!_filterIsTrivial) {
-                tmappUI.setFilterInfo(_unfilteredAnnotations.length, annotations.length);
-            }
+        overlayHandler.updateAnnotations(annotations);
+        if (_annotationList) {
+            _annotationList.updateData(annotations);
+        }
+        else {
+            console.warn("No annotation list has been set.");
+        }
+        if (!_filterIsTrivial) {
+            tmappUI.setFilterInfo(_unfilteredAnnotations.length, annotations.length);
         }
     }
 
@@ -50,8 +48,8 @@ const annotationVisuals = (function() {
             tmappUI.setFilterError(error);
             return;
         }
-        _filterAndUpdate();
         _filterIsTrivial = query.length === 0;
+        _filterAndUpdate();
         if (_filterIsTrivial) {
             tmappUI.clearFilterInfo();
         }

--- a/public/js/annotationVisuals.js
+++ b/public/js/annotationVisuals.js
@@ -9,6 +9,7 @@ const annotationVisuals = (function() {
     let _unfilteredAnnotations = [];
     let _filter = filters.getFilterFromQuery("");
     let _filterIsTrivial = true;
+    let _lastQueryWasValid = true;
 
     function _filterAndUpdate() {
         const annotations = _unfilteredAnnotations.filter(annotation => {
@@ -22,7 +23,7 @@ const annotationVisuals = (function() {
         else {
             console.warn("No annotation list has been set.");
         }
-        if (!_filterIsTrivial) {
+        if (!_filterIsTrivial && _lastQueryWasValid) {
             tmappUI.setFilterInfo(_unfilteredAnnotations.length, annotations.length);
         }
     }
@@ -31,13 +32,14 @@ const annotationVisuals = (function() {
         try {
             const filter = filters.getFilterFromQuery(query);
             _filter = filter;
+            _filterIsTrivial = query.length === 0;
+            _lastQueryWasValid = true;
         }
         catch (e) {
             const error = e.message;
             tmappUI.setFilterError(error);
-            return;
+            _lastQueryWasValid = false;
         }
-        _filterIsTrivial = query.length === 0;
     }
 
     /**
@@ -59,7 +61,7 @@ const annotationVisuals = (function() {
     function setFilterQuery(query) {
         _setFilter(query);
         _filterAndUpdate();
-        if (_filterIsTrivial) {
+        if (_filterIsTrivial && _lastQueryWasValid) {
             tmappUI.clearFilterInfo();
         }
     }
@@ -73,9 +75,6 @@ const annotationVisuals = (function() {
      */
     function setFilterQueryWithoutUpdating(query) {
         _setFilter(query);
-        if (_filterIsTrivial) {
-            tmappUI.clearFilterInfo();
-        }
     }
 
     /**

--- a/public/js/annotationVisuals.js
+++ b/public/js/annotationVisuals.js
@@ -6,6 +6,22 @@ const annotationVisuals = (function() {
     "use strict";
 
     let _annotationList = null;
+    let _unfilteredAnnotations = [];
+    let _filter = filters.getFilterFromQuery("");
+
+    function _filterAndUpdate() {
+        const annotations = _unfilteredAnnotations.filter(annotation => {
+            const filterableAnnotation = filters.preprocessDatumBeforeFiltering(annotation);
+            return _filter.evaluate(filterableAnnotation);
+        });
+        overlayHandler.updateAnnotations(annotations);
+        if (_annotationList) {
+            _annotationList.updateData(annotations);
+        }
+        else {
+            console.warn("No annotation list has been set.");
+        }
+    }
 
     /**
      * Set the annotation list object that should be used to disply
@@ -13,23 +29,24 @@ const annotationVisuals = (function() {
      * update is called.
      * @param {AnnotationList} annotationList The list to use.
      */
-     function setAnnotationList(annotationList) {
-         _annotationList = annotationList;
-     }
+    function setAnnotationList(annotationList) {
+        _annotationList = annotationList;
+    }
+
+    // TODO: Document
+    function setFilterQuery(query) {
+        const filter = filters.getFilterFromQuery(query);
+        _filter = filter;
+        _filterAndUpdate();
+    }
 
     /**
      * Update the current visuals for the annotations.
      * @param {Array} annotations All currently placed annotations.
      */
     function update(annotations){
-        // Update the annotations in the overlay
-    	overlayHandler.updateAnnotations(annotations);
-        if (_annotationList) {
-            _annotationList.updateData(annotations);
-        }
-        else {
-            console.warn("No annotation list has been set.");
-        }
+        _unfilteredAnnotations = annotations;
+        _filterAndUpdate();
     }
 
     /**
@@ -49,6 +66,7 @@ const annotationVisuals = (function() {
     return {
         update: update,
         setAnnotationList: setAnnotationList,
+        setFilterQuery: setFilterQuery,
         clear: clear
     };
 })();

--- a/public/js/annotationVisuals.js
+++ b/public/js/annotationVisuals.js
@@ -52,6 +52,9 @@ const annotationVisuals = (function() {
         }
         _filterAndUpdate();
         _filterIsTrivial = query.length === 0;
+        if (_filterIsTrivial) {
+            tmappUI.clearFilterInfo();
+        }
     }
 
     /**

--- a/public/js/annotationVisuals.js
+++ b/public/js/annotationVisuals.js
@@ -37,7 +37,12 @@ const annotationVisuals = (function() {
         _annotationList = annotationList;
     }
 
-    // TODO: Document
+    /**
+     * Set the query that should be used to filter annotations in the
+     * visuals.
+     * @param {string} query The filter query to be used. Should have
+     * the same format as in filters.getFilterFromQuery().
+     */
     function setFilterQuery(query) {
         try {
             const filter = filters.getFilterFromQuery(query);

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -223,7 +223,10 @@ const filters = (function () {
     function parseParenthesizedSubfilter(tokens) {
         const filter = parseFilter(tokens);
         const rightParenthesis = tokens.shift();
-        if (rightParenthesis && rightParenthesis.type === tokenTypes.rightP) {
+        if (!rightParenthesis) {
+            throw new Error("Expected ')'");
+        }
+        else if (rightParenthesis.type === tokenTypes.rightP) {
             if (tokens.length === 0) {
                 return filter;
             }

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -223,14 +223,15 @@ const filters = (function () {
     function parseParenthesizedSubfilter(tokens) {
         const filter = parseFilter(tokens);
         const rightParenthesis = tokens.shift();
-        if (rightParenthesis.type === tokenTypes.rightP) {
+        if (rightParenthesis && rightParenthesis.type === tokenTypes.rightP) {
             if (tokens.length === 0) {
                 return filter;
             }
             else {
                 return parseCombinedSubfilter(filter, tokens);
             }
-        } else {
+        }
+        else {
             throw new Error(`Expected ')', got '${rightParenthesis.value}'`);
         }
     }

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -1,4 +1,4 @@
-const annotationFilters = (function () {
+const filters = (function () {
     "use strict";
 
 
@@ -184,15 +184,20 @@ const annotationFilters = (function () {
 
     function tokenizeQuery(query) {
         const rawTokens = query.match(tokenExp);
-        const tokenInfo = rawTokens.map(rawToken => {
-            const value = rawToken.trim();
-            const type = getTokenType(value);
-            return {
-                value: value,
-                type: type
-            };
-        });
-        return tokenInfo;
+        if (rawTokens) {
+            const tokenInfo = rawTokens.map(rawToken => {
+                const value = rawToken.trim();
+                const type = getTokenType(value);
+                return {
+                    value: value,
+                    type: type
+                };
+            });
+            return tokenInfo;
+        }
+        else {
+            return [];
+        }
     }
 
     function parsePrimitiveSubfilter(key, tokens) {

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -116,7 +116,7 @@ const filters = (function () {
         }
 
         evaluate(input) {
-            return input[this.key] === this.value;
+            return input[this.key] === this.value.evaluate(input);
         }
     }
 
@@ -128,7 +128,7 @@ const filters = (function () {
         }
 
         evaluate(input) {
-            return input[this.key] > this.value;
+            return input[this.key] > this.value.evaluate(input);
         }
     }
 
@@ -140,7 +140,27 @@ const filters = (function () {
         }
 
         evaluate(input) {
-            return input[this.key] < this.value;
+            return input[this.key] < this.value.evaluate(input);
+        }
+    }
+
+    const FilterValue {
+        constructor(value) {
+            this.value = value;
+        }
+
+        evaluate(input) {
+            return this.value;
+        }
+    }
+
+    const FilterKeyValue {
+        constructor(value) {
+            super(value);
+        }
+
+        evaluate(input) {
+            return input[this.value];
         }
     }
 
@@ -171,13 +191,15 @@ const filters = (function () {
     function getPrimitiveValue(token) {
         switch (token.type) {
             case tokenTypes.boolValue:
-                return token.value === "true";
+                return new FilterValue(token.value === "true");
             case tokenTypes.stringValue:
-                return token.value.slice(1, -1);
+                return new FilterValue(token.value.slice(1, -1));
             case tokenTypes.numberValue:
-                return Number(token.value);
+                return new FilterValue(Number(token.value));
+            case tokenTypes.key:
+                return new FilterKeyValue(token.value);
             default:
-                throw new Error(`Expected a string or a number, got '${token.value}'`);
+                throw new Error(`Expected a string, a boolean, a number, or a key, got '${token.value}'`);
         }
     }
 

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -154,7 +154,7 @@ const filters = (function () {
         }
     }
 
-    class FilterKeyValue {
+    class FilterKeyValue extends FilterValue {
         constructor(value) {
             super(value);
         }

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -193,7 +193,7 @@ const filters = (function () {
 
     function getPrimitiveValue(token) {
         if (!token) {
-            throw new Error("Expected a string, a boolean, a number, or a key");
+            throw new Error("Expected a value or a key");
         }
         switch (token.type) {
             case tokenTypes.boolValue:
@@ -205,7 +205,7 @@ const filters = (function () {
             case tokenTypes.key:
                 return new FilterKeyValue(token.value);
             default:
-                throw new Error(`Expected a string, a boolean, a number, or a key, got '${token.value}'`);
+                throw new Error(`Expected a value or a key, got '${token.value}'`);
         }
     }
 

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -1,0 +1,289 @@
+const annotationFilters = (function () {
+    "use strict";
+
+
+    const tokenTypes = {
+        and: Symbol("Intersection"),
+        or: Symbol("Union"),
+        not: Symbol("Negation"),
+        eq: Symbol("Equality"),
+        gt: Symbol("Greater than"),
+        lt: Symbol("Less than"),
+        key: Symbol("Key"),
+        boolValue: Symbol("Boolean value"),
+        stringValue: Symbol("String value"),
+        numberValue: Symbol("Number value"),
+        leftP: Symbol("Left parenthesis"),
+        rightP: Symbol("Right parenthesis")
+    };
+
+    const tokenExp = /\s*(("[^"]*")|('[^']*')|([a-zA-Z]+)|(-?\d+(\.\d+)?)|=|>|<|\(|\)|\[|\])\s*/g;
+    const keyExp = /^[a-zA-Z]+\S*$/;
+    const boolValueExp = /^(false)|(true)$/;
+    const stringValueExp = /^(("[^"]*")|('[^']*'))$/;
+    const numberValueExp = /^-?\d+(\.\d+)?$/;
+
+    function getTokenType(token) {
+        switch (token) {
+            case "AND":
+            case "and":
+            return tokenTypes.and;
+            case "OR":
+            case "or":
+            return tokenTypes.or;
+            case "NOT":
+            case "not":
+            return tokenTypes.not;
+            case "=":
+            case "IS":
+            case "is":
+            return tokenTypes.eq;
+            case ">":
+            return tokenTypes.gt;
+            case "<":
+            return tokenTypes.lt;
+            case "(":
+            case "[":
+            return tokenTypes.leftP;
+            case ")":
+            case "]":
+            return tokenTypes.rightP;
+            default:
+            if (boolValueExp.test(token)) {
+                return tokenTypes.boolValue;
+            }
+            else if (keyExp.test(token)) {
+                return tokenTypes.key;
+            }
+            else if (stringValueExp.test(token)) {
+                return tokenTypes.stringValue;
+            }
+            else if (numberValueExp.test(token)) {
+                return tokenTypes.numberValue;
+            }
+            else {
+                // Raise some error
+            }
+        }
+    }
+
+    class Filter {
+        evaluate(input) {
+            return true;
+        }
+    }
+
+    class NegationFilter extends Filter {
+        constructor(operand) {
+            super();
+            this.operand = operand;
+        }
+
+        evaluate(input) {
+            return !this.operand.evaluate(input);
+        }
+    }
+
+    class IntersectionFilter extends Filter {
+        constructor(lhs, rhs) {
+            super();
+            this.lhs = lhs;
+            this.rhs = rhs;
+        }
+
+        evaluate(input) {
+            return this.lhs.evaluate(input) && this.rhs.evaluate(input);
+        }
+    }
+
+    class UnionFilter extends Filter {
+        constructor(lhs, rhs) {
+            super();
+            this.lhs = lhs;
+            this.rhs = rhs;
+        }
+
+        evaluate(input) {
+            return this.lhs.evaluate(input) || this.rhs.evaluate(input);
+        }
+    }
+
+    class EqualityFilter extends Filter {
+        constructor(key, value) {
+            super();
+            this.key = key;
+            this.value = value;
+        }
+
+        evaluate(input) {
+            console.log(input, this.key, this.value);
+            return input[this.key] === this.value;
+        }
+    }
+
+    class GreaterThanFilter extends Filter {
+        constructor(key, value) {
+            super();
+            this.key = key;
+            this.value = value;
+        }
+
+        evaluate(input) {
+            return input[this.key] > this.value;
+        }
+    }
+
+    class LessThanFilter extends Filter {
+        constructor(key, value) {
+            super();
+            this.key = key;
+            this.value = value;
+        }
+
+        evaluate(input) {
+            return input[this.key] < this.value;
+        }
+    }
+
+    function getPrimitiveFilterConstructor(token) {
+        switch (token.type) {
+            case tokenTypes.eq:
+            return EqualityFilter;
+            case tokenTypes.gt:
+            return GreaterThanFilter;
+            case tokenTypes.lt:
+            return LessThanFilter;
+            default:
+            throw new Error(`Expected '=', '>' or '<', got '${token.value}'`);
+        }
+    }
+
+    function getCombinedFilterConstructor(token) {
+        switch (token.type) {
+            case tokenTypes.and:
+            return IntersectionFilter;
+            case tokenTypes.or:
+            return UnionFilter;
+            default:
+            throw new Error(`Expected 'AND' or 'OR', got '${token.value}'`);
+        }
+    }
+
+    function getPrimitiveValue(token) {
+        switch (token.type) {
+            case tokenTypes.boolValue:
+            return token.value === "true";
+            case tokenTypes.stringValue:
+            return token.value.slice(1, -1);
+            case tokenTypes.numberValue:
+            return Number(token.value);
+            default:
+            throw new Error(`Expected a string or a number, got '${token.value}'`);
+        }
+    }
+
+    function tokenizeQuery(query) {
+        const rawTokens = query.match(tokenExp);
+        const tokenInfo = rawTokens.map(rawToken => {
+            const value = rawToken.trim();
+            const type = getTokenType(value);
+            return {
+                value: value,
+                type: type
+            };
+        });
+        return tokenInfo;
+    }
+
+    function parsePrimitiveSubfilter(key, tokens) {
+        const operationToken = tokens.shift();
+        const filterConstructor = getPrimitiveFilterConstructor(operationToken);
+        const rhsToken = tokens.shift();
+        const rhsValue = getPrimitiveValue(rhsToken);
+        const filter = new filterConstructor(key, rhsValue);
+        if (tokens.length === 0 || tokens[0].type === tokenTypes.rightP) {
+            return filter;
+        }
+        else {
+            return parseCombinedSubfilter(filter, tokens);
+        }
+    }
+
+    function parseCombinedSubfilter(filter, tokens) {
+        const operationToken = tokens.shift();
+        const filterConstructor = getCombinedFilterConstructor(operationToken);
+        const rhs = parseFilter(tokens);
+        return new filterConstructor(filter, rhs);
+    }
+
+    function parseParenthesizedSubfilter(tokens) {
+        const filter = parseFilter(tokens);
+        const rightParenthesis = tokens.shift();
+        if (rightParenthesis.type === tokenTypes.rightP) {
+            if (tokens.length === 0) {
+                return filter;
+            }
+            else {
+                return parseCombinedSubfilter(filter, tokens);
+            }
+        } else {
+            throw new Error(`Expected ')', got '${rightParenthesis.value}'`);
+        }
+    }
+
+    function parseFilter(tokens) {
+        if (tokens.length === 0) {
+            return new Filter(); // Trivial, all-passing filter
+        }
+        const token = tokens.shift();
+        if (token.type === tokenTypes.not) {
+            const negatedFilter = parseFilter(tokens);
+            return new NegationFilter(negatedFilter);
+        }
+        else if (token.type === tokenTypes.leftP) {
+            return parseParenthesizedSubfilter(tokens);
+        }
+        else if (token.type === tokenTypes.key) {
+            return parsePrimitiveSubfilter(token.value, tokens);
+        }
+        else {
+            throw new Error(`Expected key, '(', or 'NOT', got '${token.value}'`);
+        }
+    }
+
+    function getFilterFromQuery(query) {
+        const tokens = tokenizeQuery(query);
+        const filter = parseFilter(tokens);
+        if (tokens.length === 0) {
+            return filter;
+        }
+        else {
+            const unexpectedToken = tokens.shift();
+            throw new Error(`Unexpected '${unexpectedToken.value}'`);
+        }
+    }
+
+    /**
+     * Create an object that contains the filterable properties of an
+     * annotation.
+     * @param {annotationHandler.Annotation} annotation The annotation to be
+     * processed.
+     * @return {Object} The processed object.
+     */
+    function preprocessDatumBeforeFiltering(annotation) {
+        return {
+            class: annotation.mclass,
+            author: annotation.author,
+            comments: annotation.comments ? annotation.comments.length : 0,
+            bookmarked: annotation.bookmarked,
+            x: annotation.centroid.x,
+            y: annotation.centroid.y,
+            z: annotation.z,
+        };
+    }
+
+    return {
+        getFilterFromQuery: getFilterFromQuery,
+        preprocessDatumBeforeFiltering: preprocessDatumBeforeFiltering
+    };
+})();

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -312,6 +312,8 @@ const filters = (function () {
             author: annotation.author,
             comments: annotation.comments ? annotation.comments.length : 0,
             bookmarked: annotation.bookmarked,
+            region: annotation.points.length > 1,
+            marker: annotation.points.length === 1,
             x: annotation.centroid.x,
             y: annotation.centroid.y,
             z: annotation.z,

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -144,7 +144,7 @@ const filters = (function () {
         }
     }
 
-    const FilterValue {
+    class FilterValue {
         constructor(value) {
             this.value = value;
         }
@@ -154,7 +154,7 @@ const filters = (function () {
         }
     }
 
-    const FilterKeyValue {
+    class FilterKeyValue {
         constructor(value) {
             super(value);
         }

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -27,43 +27,43 @@ const filters = (function () {
         switch (token) {
             case "AND":
             case "and":
-            return tokenTypes.and;
+                return tokenTypes.and;
             case "OR":
             case "or":
-            return tokenTypes.or;
+                return tokenTypes.or;
             case "NOT":
             case "not":
-            return tokenTypes.not;
+                return tokenTypes.not;
             case "=":
             case "IS":
             case "is":
-            return tokenTypes.eq;
+                return tokenTypes.eq;
             case ">":
-            return tokenTypes.gt;
+                return tokenTypes.gt;
             case "<":
-            return tokenTypes.lt;
+                return tokenTypes.lt;
             case "(":
             case "[":
-            return tokenTypes.leftP;
+                return tokenTypes.leftP;
             case ")":
             case "]":
-            return tokenTypes.rightP;
+                return tokenTypes.rightP;
             default:
-            if (boolValueExp.test(token)) {
-                return tokenTypes.boolValue;
-            }
-            else if (keyExp.test(token)) {
-                return tokenTypes.key;
-            }
-            else if (stringValueExp.test(token)) {
-                return tokenTypes.stringValue;
-            }
-            else if (numberValueExp.test(token)) {
-                return tokenTypes.numberValue;
-            }
-            else {
-                // Raise some error
-            }
+                if (boolValueExp.test(token)) {
+                    return tokenTypes.boolValue;
+                }
+                else if (keyExp.test(token)) {
+                    return tokenTypes.key;
+                }
+                else if (stringValueExp.test(token)) {
+                    return tokenTypes.stringValue;
+                }
+                else if (numberValueExp.test(token)) {
+                    return tokenTypes.numberValue;
+                }
+                else {
+                    throw new Error(`Unexpected token: '${token}'`);
+                }
         }
     }
 
@@ -116,7 +116,6 @@ const filters = (function () {
         }
 
         evaluate(input) {
-            console.log(input, this.key, this.value);
             return input[this.key] === this.value;
         }
     }
@@ -148,37 +147,37 @@ const filters = (function () {
     function getPrimitiveFilterConstructor(token) {
         switch (token.type) {
             case tokenTypes.eq:
-            return EqualityFilter;
+                return EqualityFilter;
             case tokenTypes.gt:
-            return GreaterThanFilter;
+                return GreaterThanFilter;
             case tokenTypes.lt:
-            return LessThanFilter;
+                return LessThanFilter;
             default:
-            throw new Error(`Expected '=', '>' or '<', got '${token.value}'`);
+                throw new Error(`Expected '=', '>' or '<', got '${token.value}'`);
         }
     }
 
     function getCombinedFilterConstructor(token) {
         switch (token.type) {
             case tokenTypes.and:
-            return IntersectionFilter;
+                return IntersectionFilter;
             case tokenTypes.or:
-            return UnionFilter;
+                return UnionFilter;
             default:
-            throw new Error(`Expected 'AND' or 'OR', got '${token.value}'`);
+                throw new Error(`Expected 'AND' or 'OR', got '${token.value}'`);
         }
     }
 
     function getPrimitiveValue(token) {
         switch (token.type) {
             case tokenTypes.boolValue:
-            return token.value === "true";
+                return token.value === "true";
             case tokenTypes.stringValue:
-            return token.value.slice(1, -1);
+                return token.value.slice(1, -1);
             case tokenTypes.numberValue:
-            return Number(token.value);
+                return Number(token.value);
             default:
-            throw new Error(`Expected a string or a number, got '${token.value}'`);
+                throw new Error(`Expected a string or a number, got '${token.value}'`);
         }
     }
 

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -165,6 +165,9 @@ const filters = (function () {
     }
 
     function getPrimitiveFilterConstructor(token) {
+        if (!token) {
+            throw new Error("Expected '=', '>' or '<'");
+        }
         switch (token.type) {
             case tokenTypes.eq:
                 return EqualityFilter;

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -189,6 +189,9 @@ const filters = (function () {
     }
 
     function getPrimitiveValue(token) {
+        if (!token) {
+            throw new Error("Expected a string, a boolean, a number, or a key");
+        }
         switch (token.type) {
             case tokenTypes.boolValue:
                 return new FilterValue(token.value === "true");

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -17,7 +17,7 @@ const filters = (function () {
         rightP: Symbol("Right parenthesis")
     };
 
-    const tokenExp = /\s*(("[^"]*")|('[^']*')|([a-zA-Z]+)|(-?\d+(\.\d+)?)|=|>|<|\(|\)|\[|\])\s*/g;
+    const tokenExp = /\s*(("[^"]*")|('[^']*')|([a-zA-Z]+)|(-?\d+(\.\d+)?)|[^\s\da-zA-Z])\s*/g;
     const keyExp = /^[a-zA-Z]+\S*$/;
     const boolValueExp = /^(false)|(true)$/;
     const stringValueExp = /^(("[^"]*")|('[^']*'))$/;

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -262,11 +262,11 @@ const filters = (function () {
     }
 
     function parseFilter(tokens) {
-        if (tokens.length === 0) {
-            return new Filter(); // Trivial, all-passing filter
-        }
         const token = tokens.shift();
-        if (token.type === tokenTypes.not) {
+        if (!token) {
+            throw new Error("Expected key, '(', or 'NOT'");
+        }
+        else if (token.type === tokenTypes.not) {
             const negatedFilter = parseFilter(tokens);
             return new NegationFilter(negatedFilter);
         }
@@ -283,13 +283,19 @@ const filters = (function () {
 
     function getFilterFromQuery(query) {
         const tokens = tokenizeQuery(query);
-        const filter = parseFilter(tokens);
         if (tokens.length === 0) {
-            return filter;
+            return new Filter(); // Trivial, all-passing filter
         }
         else {
-            const unexpectedToken = tokens.shift();
-            throw new Error(`Unexpected '${unexpectedToken.value}'`);
+            const filter = parseFilter(tokens);
+            if (tokens.length === 0) {
+                return filter;
+            }
+            else {
+                const unexpectedToken = tokens.shift();
+                throw new Error(`Unexpected '${unexpectedToken.value}'`);
+
+            }
         }
     }
 

--- a/public/js/htmlHelper.js
+++ b/public/js/htmlHelper.js
@@ -248,7 +248,7 @@ const htmlHelper = (function() {
             e.stopPropagation();
             if ((e.code === "Enter" || e.code === "NumpadEnter") && !e.shiftKey) {
                 e.preventDefault();
-		submitButton.click();
+                submitButton.click();
             }
             else if (e.code === "Escape") {
                 $("#main_content").focus();

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -283,7 +283,7 @@ const tmappUI = (function(){
         let keyUpTimeout = null;
         const keyUpTime = 3000;
         const input = $("#filter-query-input");
-        function updateQuery(query) {
+        function updateQuery() {
             const query = input.val();
             try {
                 annotationVisuals.setFilterQuery(query);

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -279,6 +279,38 @@ const tmappUI = (function(){
         });
     }
 
+    function _initAnnotationFiltering() {
+        function updateQuery(query) {
+            try {
+                annotationVisuals.setFilterQuery(query);
+                // TODO: Show success
+            }
+            catch (except) {
+                const error = except.message;
+                $("#filter-query-error").text(error);
+            }
+        }
+        let keyUpTimeout = null;
+        const keyUpTime = 3000;
+        const input = $("#filter-query-input");
+        input.keypress(e => e.stopPropagation());
+        input.keyup(e => {
+            e.stopPropagation();
+            clearTimeout(keyUpTimeout);
+            keyUpTimeout = setTimeout(() => {
+                const query = input.val();
+                updateQuery(query);
+            }, keyUpTime);
+        });
+        input.keydown(e => {
+            e.stopPropagation();
+            if (e.code === "Escape" || e.code === "Enter" || e.code === "NumpadEnter") {
+                const query = input.val();
+                updateQuery(query);
+            }
+        });
+    }
+
     function _initFocusButtonEvents() {
         $("#focus_next").click(tmapp.incrementFocus);
         $("#focus_prev").click(tmapp.decrementFocus);
@@ -417,6 +449,7 @@ const tmappUI = (function(){
         _initContextMenu();
         _initDocumentFocusFunctionality();
         _initStorageButtonEvents();
+        _initAnnotationFiltering();
         _initFocusButtonEvents();
         _initVisualizationSliders();
         _initKeyboardShortcuts();

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -283,6 +283,8 @@ const tmappUI = (function(){
         let keyUpTimeout = null;
         const keyUpTime = 3000;
         const input = $("#filter-query-input");
+        const initialQuery = input.val();
+        tmappUI.setFilterQueryWithoutUpdating(initialQuery);
         function updateQuery() {
             const query = input.val();
             annotationVisuals.setFilterQuery(query);

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -303,7 +303,6 @@ const tmappUI = (function(){
                 $("#filter-query-error").text(error);
             }
         }
-        updateQuery();
         input.keypress(e => e.stopPropagation());
         input.keyup(e => {
             e.stopPropagation();

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -280,33 +280,39 @@ const tmappUI = (function(){
     }
 
     function _initAnnotationFiltering() {
-        function updateQuery(query) {
-            try {
-                annotationVisuals.setFilterQuery(query);
-                // TODO: Show success
-            }
-            catch (except) {
-                const error = except.message;
-                $("#filter-query-error").text(error);
-            }
-        }
         let keyUpTimeout = null;
         const keyUpTime = 3000;
         const input = $("#filter-query-input");
+        function updateQuery(query) {
+            const query = input.val();
+            try {
+                annotationVisuals.setFilterQuery(query);
+                if (query.length > 0) {
+                    input.removeClass("is-invalid");
+                    input.addClass("is-valid");
+                }
+                else {
+                    input.removeClass("is-invalid");
+                    input.removeClass("is-valid");
+                }
+            }
+            catch (except) {
+                const error = except.message;
+                input.addClass("is-invalid");
+                input.removeClass("is-valid");
+                $("#filter-query-error").text(error);
+            }
+        }
         input.keypress(e => e.stopPropagation());
         input.keyup(e => {
             e.stopPropagation();
             clearTimeout(keyUpTimeout);
-            keyUpTimeout = setTimeout(() => {
-                const query = input.val();
-                updateQuery(query);
-            }, keyUpTime);
+            keyUpTimeout = setTimeout(updateQuery, keyUpTime);
         });
         input.keydown(e => {
             e.stopPropagation();
             if (e.code === "Escape" || e.code === "Enter" || e.code === "NumpadEnter") {
-                const query = input.val();
-                updateQuery(query);
+                updateQuery();
             }
         });
     }

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -285,23 +285,7 @@ const tmappUI = (function(){
         const input = $("#filter-query-input");
         function updateQuery() {
             const query = input.val();
-            try {
-                annotationVisuals.setFilterQuery(query);
-                if (query.length > 0) {
-                    input.removeClass("is-invalid");
-                    input.addClass("is-valid");
-                }
-                else {
-                    input.removeClass("is-invalid");
-                    input.removeClass("is-valid");
-                }
-            }
-            catch (except) {
-                const error = except.message;
-                input.addClass("is-invalid");
-                input.removeClass("is-valid");
-                $("#filter-query-error").text(error);
-            }
+            annotationVisuals.setFilterQuery(query);
         }
         input.keypress(e => e.stopPropagation());
         input.keyup(e => {
@@ -712,6 +696,40 @@ const tmappUI = (function(){
         $("#last_autosave").text(time || time === 0 ? txt : "");
     }
 
+    /**
+     * Indicate that there has been an error in parsing a filter query.
+     * @param {string} error The error message to display.
+     */
+    function setFilterError(error) {
+        const input = $("#filter-query-input");
+        input.addClass("is-invalid");
+        input.removeClass("is-valid");
+        $("#filter-query-error").text(error);
+    }
+
+    /**
+     * Show information about what has been filtered out.
+     * @param {number} total The total number of annotations.
+     * @param {number} remaining The number of annotations that
+     * passed through the filter.
+     */
+    function setFilterInfo(total, remaining) {
+        const input = $("#filter-query-input");
+        const info = `Showing ${remaining} out of ${total} annotations`;
+        input.removeClass("is-invalid");
+        input.addClass("is-valid");
+        $("#filter-query-info").text(info);
+    }
+
+    /**
+     * Clear information text from filter.
+     */
+    function clearFilterInfo() {
+        const input = $("#filter-query-input");
+        input.removeClass("is-invalid");
+        input.removeClass("is-valid");
+    }
+
     let _urlTimeout,
         _urlCache;
     /**
@@ -755,6 +773,9 @@ const tmappUI = (function(){
         setImageZoom: setImageZoom,
         setImageRotation: setImageRotation,
         setLastAutosave: setLastAutosave,
+        setFilterError: setFilterError,
+        setFilterInfo: setFilterInfo,
+        clearFilterInfo: clearFilterInfo,
         setURL: setURL,
         inFocus: inFocus
     };

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -284,7 +284,7 @@ const tmappUI = (function(){
         const keyUpTime = 3000;
         const input = $("#filter-query-input");
         const initialQuery = input.val();
-        tmappUI.setFilterQueryWithoutUpdating(initialQuery);
+        annotationVisuals.setFilterQueryWithoutUpdating(initialQuery);
         function updateQuery() {
             const query = input.val();
             annotationVisuals.setFilterQuery(query);

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -303,6 +303,7 @@ const tmappUI = (function(){
                 $("#filter-query-error").text(error);
             }
         }
+        updateQuery();
         input.keypress(e => e.stopPropagation());
         input.keyup(e => {
             e.stopPropagation();


### PR DESCRIPTION
Pull request for issue #42 . The user is now able to filter which annotations appear in the user interface using a simple query language. Using a query language instead of a set of buttons to control the filters was done to make filtering easier to extend in the future, as well as to make it possible to make more complex filters without cluttering the UI. The filter creation and parsing is implemented in `filters.js`.

As an example of what the filters can do, the query `(not class = "Other") and marker = true and x > 10000 and x < 20000 and (author = "Bob" or author = "Joe")` will pass the annotations through a filter that only shows single-point annotations whose x coordinates are between 10000 and 20000 that do not belong to the class "Other" and were created by either Bob or Joe.