### PR TITLE
FIX: Mostly use history.replaceState instead of history.pushState

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -791,6 +791,13 @@
     }
     window.addEventListener('resize', resizeNavbar);
 
+    // Handle browser history.back/forward()
+    window.onpopstate = function(event) {
+        $('.modal').modal('hide'); //close all modals
+        tmappUI.setOverwriteURL(true); //state already on history
+        tmapp.processURL(document.location);
+    };
+
     // Start our tmapp
     $(document).ready(() => {
         // Options when initializing tmapp

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -163,6 +163,9 @@ const tmapp = (function() {
     }
 
     function parseURL(url) {
+        if (!(url instanceof URL)) {
+            url=new URL(url);
+        }
         // Get params from URL
         const params = url.searchParams;
         const imageName = params.get("image");
@@ -175,6 +178,38 @@ const tmapp = (function() {
             rotation: params.get("rotation")
         };
         return {imageName, collab, state};
+    }
+
+    function processURL(url) {
+        const {imageName, collab, state}=parseURL(url);
+        if (imageName && imageName!==_currentImage.name) {
+            if (collab) {
+                openImage(imageName, () => {
+                    collabClient.connect(collab);
+                    if (state) {
+                        moveTo(state);
+                    }
+                });
+            }
+            else if (imageName) {
+                openImage(imageName, () => {
+                    collabPicker.open(imageName, true, () => {
+                        if (state) {
+                            moveTo(state);
+                        }
+                    });
+                });
+            }            
+        }
+        else if (collab && collab!==_collab) {
+            collabClient.connect(collab);
+            if (state) {
+                moveTo(state);
+            }
+        }
+        else if (state && state!==_currState) {
+            moveTo(state);
+        }
     }
 
     function _updateURLParams() {
@@ -427,7 +462,7 @@ const tmapp = (function() {
                     }
                     else if (imageName && collab) {
                         openImage(imageName, () => {
-                            collabClient.connect(collab)
+                            collabClient.connect(collab);
                             if (initialState) {
                                 moveTo(initialState);
                             }
@@ -764,6 +799,7 @@ const tmapp = (function() {
         moveTo: moveTo,
         makeURL: makeURL,
         parseURL: parseURL,
+        processURL: processURL,
         annotationURL: annotationURL,
         moveToAnnotation: moveToAnnotation,
         setCollab: setCollab,

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -742,19 +742,40 @@ const tmappUI = (function(){
         input.removeClass("is-valid");
     }
 
-    let _urlTimeout;
+    let _urlTimeout=0;
+    let _overwriteURL=true; //High (from start and) for 1 second after setURL => replaceState instead of pushState
+    
     /**
-     * Push a new state to the URL if standing still long enough.
+     * If next setURL to overwrite previous history state or not
+     * @param {boolean} value setURL => value?replaceState:pushState
+     */
+    function setOverwriteURL(value) {
+        _overwriteURL=value;
+    }
+    
+    /**
+     * Update URL in browser
+     * Push to history if standing still long enough.
      * @param {string} url The new state to push.
      */
     function setURL(url) {
+        if (!history.state || history.state.page!=url.href) 
+        {
+            if (_overwriteURL) {
+                history.replaceState({ "page": url.href }, "", url.href);
+            }
+            else {
+                history.pushState({ "page": url.href }, "", url.href);
+            }
+            setOverwriteURL(true);
+        }
         if (_urlTimeout) {
             clearTimeout(_urlTimeout);
         }
         _urlTimeout = setTimeout(() => {
-            window.history.pushState(null, "", url);
+            setOverwriteURL(false);
             _urlTimeout = 0;
-        }, 100);
+        }, 1000); //1 second
     }
 
     /**
@@ -788,6 +809,7 @@ const tmappUI = (function(){
         setFilterInfo: setFilterInfo,
         clearFilterInfo: clearFilterInfo,
         setURL: setURL,
+        setOverwriteURL: setOverwriteURL,
         inFocus: inFocus
     };
 })();


### PR DESCRIPTION
FEAT: Allows using history for browsing; handling of window.onpopstate
Resolves #160