### PR TITLE
Issue/174 end region adjustment

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -752,6 +752,7 @@
 <script src="js/metadataHandler.js"></script>
 <script src="js/annotationHandler.js"></script>
 <script src="js/overlayHandler.js"></script>
+<script src="js/regionEditor.js"></script>
 <script src="js/tmappUI.js"></script>
 <script src="js/tmapp.js"></script>
 <script src="js/filters.js"></script>

--- a/public/js/annotationHandler.js
+++ b/public/js/annotationHandler.js
@@ -416,12 +416,12 @@ const annotationHandler = (function (){
 
             // Send the update to collaborators
             transmit && collabClient.removeAnnotation(id);
+            regionEditor.stopEditingRegionIfBeingEdited(id);
         });
 
         _updateAnnotationCounts();
 
         // Remove the annotation from the graphics
-        regionEditor.stopEditingRegionIfBeingEdited(id);
         _updateVisuals();
     }
 

--- a/public/js/annotationHandler.js
+++ b/public/js/annotationHandler.js
@@ -421,6 +421,7 @@ const annotationHandler = (function (){
         _updateAnnotationCounts();
 
         // Remove the annotation from the graphics
+        regionEditor.stopEditingRegionIfBeingEdited(id);
         _updateVisuals();
     }
 

--- a/public/js/overlayHandler.js
+++ b/public/js/overlayHandler.js
@@ -247,6 +247,7 @@ const overlayHandler = (function (){
             },
             dragHandler: function(event) {
                 // Use a clone of the annotation to make sure the edit is permitted
+                regionEditor.stopEditingRegion();
                 const clone = annotationHandler.getAnnotationById(d.id);
                 const reference = coordinateHelper.webToImage({x: 0, y: 0});
                 const delta = coordinateHelper.webToImage(event.delta);

--- a/public/js/overlayHandler.js
+++ b/public/js/overlayHandler.js
@@ -234,6 +234,7 @@ const overlayHandler = (function (){
         new OpenSeadragon.MouseTracker({
             element: node,
             clickHandler: function(event) {
+                regionEditor.stopEditingRegion();
                 if (event.originalEvent.ctrlKey) {
                     annotationHandler.remove(d.id);
                 }
@@ -624,7 +625,6 @@ const overlayHandler = (function (){
             return;
         }
         _regionOverlay.selectAll(".region")
-            .data(regions, d => d.id)
             .filter(d => d.id === id)
             .each(function(d) { _createRegionEditControls(d, this); });
     }
@@ -639,7 +639,6 @@ const overlayHandler = (function (){
             return;
         }
         _regionOverlay.selectAll(".region")
-            .data(regions, d => d.id)
             .filter(d => d.id === id)
             .each(function(d) { _removeRegionEditControls(d, this); });
     }

--- a/public/js/regionEditor.js
+++ b/public/js/regionEditor.js
@@ -1,0 +1,54 @@
+/**
+ * Namespace for handling the region editing functionality, intended to
+ * make it easier to turn it on and off from other parts of the code.
+ * While overlayHandler has public functions for enabling and disabling
+ * editing controls for regions, these are only intended for this
+ * namespace, as this namespace is also used to make sure that only one
+ * region is being edited at a time.
+ *
+ * @namespace regionEditor
+ */
+
+const regionEditor = (function() {
+    let _currentlyEditedRegionId = null;
+
+    /**
+     * Stop editing any region that is currently being edited and begin
+     * editing a given region.
+     * @param {number} id The id of the annotation corresponding to
+     * the region.
+     */
+    function startEditingRegion(id) {
+        stopEditingRegion();
+        _currentlyEditedRegionId = id;
+        overlayHandler.startRegionEdit(id);
+    }
+
+    /**
+     * Stop editing the region currently being edited and remove its
+     * handles, if a region is currently being edited.
+     */
+    function stopEditingRegion() {
+        if (_currentlyEditedRegionId !== null) {
+            overlayHandler.stopRegionEdit(_currentlyEditedRegionId);
+            _currentlyEditedRegionId = null;
+        }
+    }
+
+    /**
+     * If a given region is currently being edited, stop editing it.
+     * @param {number} id The id of the annotation corresponding to
+     * the region.
+     */
+    function stopEditingRegionIfBeingEdited(id) {
+        if (_currentlyEditedRegionId === id) {
+            stopEditingRegion();
+        }
+    }
+
+    return {
+        setCurrentlyEditedRegion,
+        stopEditingRegion,
+        stopEditingRegionIfBeingEdited
+    };
+})();

--- a/public/js/regionEditor.js
+++ b/public/js/regionEditor.js
@@ -27,11 +27,16 @@ const regionEditor = (function() {
     /**
      * Stop editing the region currently being edited and remove its
      * handles, if a region is currently being edited.
+     * @returns {boolean} Whether or not a region editing was stopped.
      */
     function stopEditingRegion() {
         if (_currentlyEditedRegionId !== null) {
             overlayHandler.stopRegionEdit(_currentlyEditedRegionId);
             _currentlyEditedRegionId = null;
+            return true;
+        }
+        else {
+            return false;
         }
     }
 
@@ -39,10 +44,14 @@ const regionEditor = (function() {
      * If a given region is currently being edited, stop editing it.
      * @param {number} id The id of the annotation corresponding to
      * the region.
+     * @returns {boolean} Whether or not a region editing was stopped.
      */
     function stopEditingRegionIfBeingEdited(id) {
         if (_currentlyEditedRegionId === id) {
-            stopEditingRegion();
+            return stopEditingRegion();
+        }
+        else {
+            return false;
         }
     }
 

--- a/public/js/regionEditor.js
+++ b/public/js/regionEditor.js
@@ -47,7 +47,7 @@ const regionEditor = (function() {
     }
 
     return {
-        setCurrentlyEditedRegion,
+        startEditingRegion,
         stopEditingRegion,
         stopEditingRegionIfBeingEdited
     };

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -253,10 +253,11 @@ const tmapp = (function() {
     function _addMouseTracking(viewer) {
         // Handle quick and slow clicks
         function clickHandler(event) {
-            if (tmappUI.inFocus()) {
-                regionEditor.stopEditingRegion();
+            let regionWasBeingEdited = true;
+            if (tmappUI.inFocus() && event.quick) {
+                regionWasBeingEdited = regionEditor.stopEditingRegion();
             }
-            if(event.quick && !event.ctrlKey && tmappUI.inFocus()){
+            if(!regionWasBeingEdited && event.quick && !event.ctrlKey && tmappUI.inFocus()){
                 const coords = coordinateHelper.webToViewport(event.position);
                 const position = {
                     x: coords.x,

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -253,6 +253,9 @@ const tmapp = (function() {
     function _addMouseTracking(viewer) {
         // Handle quick and slow clicks
         function clickHandler(event) {
+            if (tmappUI.inFocus()) {
+                regionEditor.stopEditingRegion();
+            }
             if(event.quick && !event.ctrlKey && tmappUI.inFocus()){
                 const coords = coordinateHelper.webToViewport(event.position);
                 const position = {

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -355,6 +355,7 @@ const tmappUI = (function(){
             switch(event.which) {
                 case 27: // esc
                     annotationTool.reset();
+                    regionEditor.stopEditingRegion();
                     break;
                 case 8: // backspace
                     annotationTool.revert();


### PR DESCRIPTION
Pull request for issue #174 . Region editing mode can now be canceled either by pressing the Escape key or by clicking somewhere inside the viewport. The interface `regionEditor` now exists to make it simpler to handle region editing mode from different parts of the code, so if it needs to be canceled from any other scenarios you can simply call `regionEditor.stopEditingRegion()`.