### PR TITLE
Issue/169 self intersect

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -745,6 +745,7 @@
 <script src="classConfig.js"></script>
 <script src="js/utils/classUtils.js"></script>
 <script src="js/utils/dateUtils.js"></script>
+<script src="js/utils/mathUtils.js"></script>
 <script src="js/versionRevert.js"></script>
 <script src="js/collabClient.js"></script>
 <script src="js/collabPicker.js"></script>

--- a/public/js/annotationHandler.js
+++ b/public/js/annotationHandler.js
@@ -317,6 +317,12 @@ const annotationHandler = (function (){
             return;
         }
 
+        // Don't edit a region to intersect itself
+        if (mathUtils.pathIntersectsSelf(annotation.points)) {
+            console.warn("Cannot make a region intersect itself.");
+            return;
+        }
+
         // Check if the annotation being updated exists first
         if (updatedAnnotation === undefined) {
             throw new Error("Tried to update an annotation that doesn't exist.");

--- a/public/js/annotationTool.js
+++ b/public/js/annotationTool.js
@@ -154,6 +154,8 @@ const annotationTool = (function() {
             const last = _points.pop();
             if (last && last.x !== _nextPoint.x && last.y !== _nextPoint.y)
                 _points.push(last);
+            if (mathUtils.pathIntersectsSelf([..._points, _nextPoint], false))
+                return;
             _points.push(_nextPoint);
             _updatePending();
         }
@@ -161,7 +163,7 @@ const annotationTool = (function() {
         function complete(position) {
             _zLevel = position.z;
             _mclass = _activeMclass;
-            if (_points.length > 2) {
+            if (_points.length > 2 && !mathUtils.pathIntersectsSelf(_points)) {
                 const annotation = _getAnnotation(_points);
                 annotationHandler.add(annotation, "image");
                 reset();

--- a/public/js/annotationTool.js
+++ b/public/js/annotationTool.js
@@ -87,22 +87,22 @@ const annotationTool = (function() {
                 const annotation = _getAnnotation();
                 annotationHandler.add(annotation, "image");
                 reset();
-            } 
+            }
             else {
                 console.warn("Complete called with incomplete rectangle!");
             }
         }
 
         return {
-            click: addPoint,  
-            // Prevent starting a new rectangle by the two separate click events   
-            dblClick: function(position) { 
+            click: addPoint,
+            // Prevent starting a new rectangle by the two separate click events
+            dblClick: function(position) {
                 if (_clicks<2) { // only one click for this rect = new rect created from (half) dblClick-closing
                     console.info("Double-click close, reset to avoid creating new rectangle.");
                     reset();
                 }
-            }, 
-            complete: addPoint, 
+            },
+            complete: addPoint,
             update: function(position) {
                 if (_startPoint) {
                     _mclass = _activeMclass;
@@ -143,7 +143,7 @@ const annotationTool = (function() {
             _nextPoint = null;
             overlayHandler.updatePendingRegion(null);
         }
-        
+
         function addPoint(position) {
             _nextPoint = coordinateHelper.viewportToImage({
                 x: position.x,
@@ -152,7 +152,7 @@ const annotationTool = (function() {
             _zLevel = position.z;
             _mclass = _activeMclass;
             const last = _points.pop();
-            if (last && last.x !== _nextPoint.x && last.y !== _nextPoint.y)
+            if (last && (last.x !== _nextPoint.x || last.y !== _nextPoint.y))
                 _points.push(last);
             if (mathUtils.pathIntersectsSelf([..._points, _nextPoint], false))
                 return;
@@ -172,7 +172,7 @@ const annotationTool = (function() {
 
         return {
             click: addPoint,
-            dblClick: complete,    
+            dblClick: complete,
             complete: complete,
             update: function(position) {
                 if (_points.length) {

--- a/public/js/utils/mathUtils.js
+++ b/public/js/utils/mathUtils.js
@@ -1,0 +1,100 @@
+/**
+ * Utility functions for useful mathematical computations.
+ *
+ * @namespace mathUtils
+ */
+ const mathUtils = (function() {
+
+     // Functions below are used for checking of a polygon intersects
+     // itself. This is done by iterating through each pair of line
+     // segments that makes up the polygon, finding the transformation
+     // that turns one of these segment into the segment from (0, 0) to (1, 0),
+     // applying that transformation to the second segment, and checking
+     // if any of its points are found in the normalized segment.
+
+     function _getTransformParams(seg) {
+         const offset = seg[0];
+         const p = {
+             x: seg[1].x - offset.x,
+             y: seg[1].y - offset.y
+         };
+         const rotation = -Math.atan2(p.y, p.x);
+         const scale = 1 / Math.sqrt(p.x**2, p.y**2);
+         return {
+             offset,
+             rotation,
+             scale
+         };
+     }
+
+     function _applyTransform(point, params) {
+         // Apply translation
+         let result = {
+             x: point.x - params.offset.x,
+             y: point.y - params.offset.y
+         };
+         // Apply rotation
+         const cos = Math.cos(params.rotation);
+         const sin = Math.sin(params.rotation);
+         result = {
+             x: cos * result.x - sin * result.y,
+             y: sin * result.x + cos * result.y
+         };
+         // Apply scale
+         result = {
+             x: params.scale * result.x,
+             y: params.scale * result.y
+         };
+         return result;
+     }
+
+     function _segsIntersect(a, b) {
+         // Mathematically, segments are counted as open
+         const transformParams = _getTransformParams(a);
+         const seg = b.map(p => _applyTransform(p, transformParams));
+         const noXCrossing = seg[0].y > 0 && seg[1].y > 0 || seg[0].y < 0 && seg[1].y < 0;
+         const parallelToX = seg[0].y === seg[1].y;
+         const parallelToY = seg[0].x === seg[1].x;
+         if (noXCrossing) {
+             return false;
+         }
+         else if (parallelToX) {
+             return true;
+         }
+         else if (parallelToY) {
+             return seg[0].x > 0 && seg[0].x < 1;
+         }
+         else {
+             const dxdy =  (seg[1].x - seg[0].x) / (seg[1].y - seg[0].y);
+             const xOffset = seg[0].x - (dxdy * seg[0].y);
+             return xOffset > 0 && xOffset < 1;
+         }
+     }
+
+     /**
+      * Check whether or not a 2D path intersects itself.
+      * @param {Array<Object>} points An array of points that define
+      * the path. Each point is an object that should have x and y
+      * coordinates defined.
+      * @param {boolean} [closed=true] Whether or not there is an edge
+      * between the last and the first point of the path.
+      * @returns Whether or not the path intersects itself.
+      */
+     function pathIntersectsSelf(points, closed=true) {
+         const endpoints = closed ? [...points, points[0]] : [...points];
+         const segs = endpoints.slice(0, -1).map((p, i) => {
+             return [
+                 {x: p.x, y: p.y},
+                 {x: endpoints[i + 1].x, y: endpoints[i + 1].y}
+             ];
+         });
+         const noIntersections = segs.every((p1, i) => {
+             return segs.slice(i + 1).every(p2 => !_segsIntersect(p1, p2));
+         });
+         return !noIntersections;
+     }
+
+     return {
+         pathIntersectsSelf
+     };
+ })();

--- a/public/js/utils/mathUtils.js
+++ b/public/js/utils/mathUtils.js
@@ -45,6 +45,17 @@
              x: params.scale * result.x,
              y: params.scale * result.y
          };
+         // Due to rounding errors, it's possible for the start of the
+         // segment that follows the reference segment to be off from
+         // (1, 0) by a very small amount. To circumvent this, the
+         // value is rounded to some number of decimals that is large
+         // enough to not cause inaccuracy, but small enough to avoid
+         // the rounding errors. Could cause issues if you ever want
+         // to work with images wider than 10 billion pixels.
+         result = {
+             x: Number(result.x.toFixed(10)),
+             y: Number(result.y.toFixed(10))
+         }
          return result;
      }
 

--- a/public/js/utils/mathUtils.js
+++ b/public/js/utils/mathUtils.js
@@ -19,7 +19,7 @@
              y: seg[1].y - offset.y
          };
          const rotation = -Math.atan2(p.y, p.x);
-         const scale = 1 / Math.sqrt(p.x**2, p.y**2);
+         const scale = 1 / Math.sqrt(p.x**2 + p.y**2);
          return {
              offset,
              rotation,

--- a/public/js/utils/mathUtils.js
+++ b/public/js/utils/mathUtils.js
@@ -12,6 +12,7 @@
      // applying that transformation to the second segment, and checking
      // if any of its points are found in the normalized segment.
 
+     // Get the parameters needed to transform a given segment to [(0,0),(1,0)]
      function _getTransformParams(seg) {
          const offset = seg[0];
          const p = {
@@ -27,6 +28,8 @@
          };
      }
 
+     // Apply the transform parameters derived in _getTransformParams()
+     // to a given point.
      function _applyTransform(point, params) {
          // Apply translation
          let result = {
@@ -59,6 +62,9 @@
          return result;
      }
 
+     // Check if two line segments intersect, where the segments are arrays 
+     // with two objects that specify the x and y coordinates of the
+     // two bounding points of the segment.
      function _segsIntersect(a, b) {
          // Mathematically, segments are counted as open
          const transformParams = _getTransformParams(a);


### PR DESCRIPTION
Pull request for issue #169 . The prevention of self-intersection is done in `annotationTool`, and uses logic from `mathUtils`. It may be relevant to move more general math functions to `mathUtils` at some point, e.g. `getCentroid()`. Note when testing that there may be situations where it may look like there is an intersection, e.g. clicking [(0,0), (1, 0), (0, 1), (1, 1)], but the intersection here only comes from the current hypothetical closing segment; it is not possible to complete the region without adding more vertices that make it non-intersecting, as seen in this image:
![bild](https://user-images.githubusercontent.com/31703366/146097244-ac3ea953-f5c2-4827-8c8e-7c8ffd578cc2.png)
