### PR TITLE
Issue/186 i pv6 url

### DIFF
--- a/cytobrowser.js
+++ b/cytobrowser.js
@@ -85,7 +85,13 @@ app.ws("/collaboration/:id", (ws, req) => {
 
 // Begin listening on the specified interface
 const listener = app.listen(port, hostname, () => {
-    const address = listener.address().address;
+    let address = listener.address().address;
     const port = listener.address().port;
+
+    const family = listener.address().family; //IPv6
+    if (family === 'IPv6') {
+        address = `[${address}]`;
+    }
+
     console.info(`CytoBrowser server listening at http://${address}:${port}`);
 });


### PR DESCRIPTION
Wrap IPv6 address in [...] to create valid url

My /etc/hosts
has the line (from install): "::1     localhost ip6-localhost ip6-loopback"  

Thus `node cytobrowser.js` failed to print correct URL
