### PR TITLE
Visualisation predictions on side menu

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -529,6 +529,7 @@
                     <li><code>x</code> &#8211; The x position of the annotation's centroid.</li>
                     <li><code>y</code> &#8211; The y position of the annotation's centroid.</li>
                     <li><code>z</code> &#8211; The z position of the annotation.</li>
+                    <li><code>prediction</code> &#8211; The cancer probability of the annotation.</li>
                 </ul>
                 <p>
                     The session picker uses a different set of keys
@@ -548,12 +549,13 @@
                     Values specify what the annotation properties should
                     be compared to in the filter. A value can be a boolean,
                     in which case it is specified as <code>true</code> or
-                    <code>false</code>, a string, in which case a quotation
-                    mark should be placed on either side of the value, or
-                    a number, which can be either an integer or a real number.
-                    In addition, the value can be specified as a key, in
-                    which case two properties of the annotation are compared
-                    to each other.
+                    <code>false</code>, a null object, in which case it is
+                    specified as <code>null</code>, a string, in which case
+                    a quotation mark should be placed on either side of the
+                    value, or a number, which can be either an integer or a
+                    real number. In addition, the value can be specified as
+                    a key, in which case two properties of the annotation are
+                    compared to each other.
                 </p>
               <h5>Comparisons</h5>
                 <p>
@@ -590,6 +592,7 @@
                     <li><code>bookmarked &equals; true OR comments &gt; 0</code> &#8211; Annotations that have either been bookmarked or commented on.</li>
                     <li><code>bookmarked &equals; true AND (class &equals; "Other" OR comments &gt; 0)</code> &#8211; Bookmarked annotations that either have the class "Other" or have been commented on.</li>
                     <li><code>x &gt; y</code> &#8211; Annotations where the x position is greater than the y position.</li>
+                    <li><code>prediction &equals; null</code> &#8211; Annotations where the prediction has not been defined.</li>
                 </ul>
           </div>
         </div>

--- a/public/js/annotationHandler.js
+++ b/public/js/annotationHandler.js
@@ -124,7 +124,9 @@ const annotationHandler = (function (){
             }),
             author: annotation.author,
             id: annotation.id,
-            originalId: annotation.originalId
+            originalId: annotation.originalId,
+
+            prediction: annotation.prediction
         };
 
         if (include_computables) { //and defaults

--- a/public/js/filters.js
+++ b/public/js/filters.js
@@ -19,7 +19,8 @@ const filters = (function () {
         stringValue: Symbol("String value"),
         numberValue: Symbol("Number value"),
         leftP: Symbol("Left parenthesis"),
-        rightP: Symbol("Right parenthesis")
+        rightP: Symbol("Right parenthesis"),
+        nullValue: Symbol("Null value")
     };
 
     const _tokenExp = /\s*(("[^"]*")|('[^']*')|([a-zA-Z]+)|(-?\d+(\.\d+)?)|[^\s\da-zA-Z])\s*/g;
@@ -27,6 +28,7 @@ const filters = (function () {
     const _boolValueExp = /^(false)|(true)$/;
     const _stringValueExp = /^(("[^"]*")|('[^']*'))$/;
     const _numberValueExp = /^-?\d+(\.\d+)?$/;
+    const _nullValueExp = /^(null)$/;
 
     function _getTokenType(token) {
         switch (token) {
@@ -56,6 +58,9 @@ const filters = (function () {
             default:
                 if (_boolValueExp.test(token)) {
                     return _tokenTypes.boolValue;
+                }
+                else if (_nullValueExp.test(token)) {
+                    return _tokenTypes.nullValue;
                 }
                 else if (_keyExp.test(token)) {
                     return _tokenTypes.key;
@@ -138,6 +143,9 @@ const filters = (function () {
         }
 
         evaluate(input) {
+            if (this.key === "prediction" && input[this.key] === null) {
+                return false
+            }
             return input[this.key] > this.value.evaluate(input);
         }
     }
@@ -150,6 +158,9 @@ const filters = (function () {
         }
 
         evaluate(input) {
+            if (this.key === "prediction" && input[this.key] === null) {
+                return false
+            }
             return input[this.key] < this.value.evaluate(input);
         }
     }
@@ -214,6 +225,8 @@ const filters = (function () {
                 return new FilterValue(Number(token.value));
             case _tokenTypes.key:
                 return new FilterKeyValue(token.value);
+            case _tokenTypes.nullValue:
+                return new FilterValue(null)
             default:
                 throw new Error(`Expected a value or a key, got '${token.value}'`);
         }
@@ -317,7 +330,7 @@ const filters = (function () {
      * <equality> ::= "IS"|"is"|"="
      * <gt> ::= ">"
      * <lt> ::= "<"
-     * <value> ::= <key>|"true"|"false"|<string>|<integer>|<float>
+     * <value> ::= <key>|"true"|"false"|<string>|<integer>|<float>|"null"
      *
      * <key> corresponds to any sequence of alphanumeric characters that
      * start with a letter, and <string> corresponds to any sequence
@@ -360,6 +373,7 @@ const filters = (function () {
             x: annotation.centroid.x,
             y: annotation.centroid.y,
             z: annotation.z,
+            prediction: annotation.prediction,
         };
     }
 

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -91,17 +91,13 @@ const tmappUI = (function(){
     function _initAnnotationList() {
         const list = new SortableList("#annotation-list", "#rtoolbar", "id", [
             {
-                name: "x",
-                key: "x",
-                minWidth: "5em",
-                selectFun: d => Math.round(d.centroid.x),
-                sortable: true
-            },
-            {
-                name: "y",
-                key: "y",
-                minWidth: "5em",
-                selectFun: d => Math.round(d.centroid.y),
+                name: "Prediction",
+                key: "prediction",
+                title: "Cancer probability score",
+                minWidth: "8em",
+                displayFun: (elem, d) => {
+                    $(elem).html(d.prediction === null ? null : d.prediction.toFixed(4));
+                },
                 sortable: true
             },
             {


### PR DESCRIPTION
Visualisation of predictions on the side menu, replacing x and y coordinates, and filtering annotations on predictions.

1. Removed x and y coordinates from side menu
2. Included and display predictions (4 decimals if number or nothing if null) on side menu
3. Filtering annotation on predictions (prediction = null, prediction < number, prediction > number)
4. Updated filtering "help" description to reflect the new filtering key