### PR TITLE
Slow down z-level changes on scroll (#308)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -593,6 +594,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1004,6 +1006,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -417,18 +417,22 @@ const tmapp = (function() {
             event.position = new OpenSeadragon.Point(event.offsetX,event.offsetY);
             moveHandler(event);
         });
-
+        
         // Add hook to scroll without zooming, didn't seem possible without
+        let timeout = null;
         function scrollHook(event){
             // Ctrl scroll -> Focus change
+            clearTimeout(timeout);
             if (event.originalEvent.ctrlKey) {
                 event.preventDefaultAction = true;
-                if (event.scroll > 0) {
-                    incrementFocus();
-                }
-                else if (event.scroll < 0) {
-                    decrementFocus();
-                }
+                timeout = setTimeout(() => {
+                    if (event.scroll > 0) {
+                        incrementFocus();
+                    }
+                    else if (event.scroll < 0) {
+                        decrementFocus();
+                    }
+                },100)
             }
             // Alt scroll -> MarkerSize change
             if (event.originalEvent.altKey) {


### PR DESCRIPTION
This PR slows down focus (z-level) changes when using Ctrl + touchpad scroll, making the feature more usable on laptops where scroll events can fire rapidly. Fixes #308. 