### PR TITLE
Add refresh button to image browser (#260)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -344,20 +344,24 @@
 
     <!-- Image browser -->
     <div class="modal fade" id="image_browser" tabindex="-1" role="dialog">
-      <div class="modal-dialog modal-xl" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title">Select an image</h5>
-            <button type="button" class="close" data-dismiss="modal">
-              <span>&times;</span>
-            </button>
-          </div>
-          <div id="available_images" class="modal-body" style="overflow-y: auto; max-height:85vh;">
-
-          </div>
+        <div class="modal-dialog modal-xl" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Select an image</h5>
+                    <div class="d-flex">
+                        <button id="image_list_refresh" class="btn btn-link" type="button" title="Refresh">
+                            Refresh
+                        </button>
+                        <button type="button" class="close" data-dismiss="modal">
+                            <span>&times;</span>
+                        </button>
+                    </div>
+                </div>
+                <div id="available_images" class="modal-body" style="overflow-y: auto; max-height:85vh;">
+                </div>
+            </div>
         </div>
-      </div>
-    </div> <!-- End of image browser -->
+    </div> <!-- end of image browser -->
 
     <!-- Version select -->
     <div class="modal fade" id="version_select" tabindex="-1" role="dialog">

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -1038,6 +1038,13 @@ function init({ imageName, collab, initialState }) {
             throw new Error ("Tried to adjust scalebar without a viewer.");
         }
     }
+
+    /**
+     * Refreshes the list of available images in the image browser.
+     * Fetches image data from the server (/images), updates the
+     * image cache (_images), clears and repopulates the image browser UI, and
+     * displays an error/empty-state message if needed.
+     */
 function refreshImageBrowser() {
 
     _fetchImages((err, response) => {

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -1045,28 +1045,28 @@ function _fetchImages(done) {
      * image cache (_images), clears and repopulates the image browser UI, and
      * displays an error/empty-state message if needed.
      */
-function refreshImageBrowser() {
+    function refreshImageBrowser() {
 
-    _fetchImages((err, response) => {
+        _fetchImages((err, response) => {
 
-        if (err) {
-            console.error(err);
-            tmappUI.displayImageError("unexpected");
-            return;
-        }
+            if (err) {
+                console.error(err);
+                tmappUI.displayImageError("unexpected");
+                return;
+            }
 
-        const missingDataDir = response.missingDataDir;
-        const images = response.images || [];
+            const missingDataDir = response.missingDataDir;
+            const images = response.images || [];
 
-        _images = images;
-        tmappUI.clearImageBrowser();
-        tmappUI.updateImageBrowser(images);
+            _images = images;
+            tmappUI.clearImageBrowser();
+            tmappUI.updateImageBrowser(images);
 
-        if (missingDataDir) tmappUI.displayImageError("missingdatadir");
-        else if (images.length === 0) tmappUI.displayImageError("noavailableimages");
-        else tmappUI.clearImageError && tmappUI.clearImageError();
-    });
-}
+            if (missingDataDir) tmappUI.displayImageError("missingdatadir");
+            else if (images.length === 0) tmappUI.displayImageError("noavailableimages");
+            else tmappUI.clearImageError && tmappUI.clearImageError();
+        });
+    }
 
 
     return {

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -660,47 +660,48 @@ function _fetchImages(done) {
      * @param {number} options.initialState.z Z level in viewport.
      * @param {number} options.initialState.zoom Zoom in viewport.
      */
-function init({ imageName, collab, initialState }) {
-    _fetchImages((err, response) => {
-        tmappUI.setUserName(userInfo.getName());
+    
+    function init({ imageName, collab, initialState }) {
+        _fetchImages((err, response) => {
+            tmappUI.setUserName(userInfo.getName());
 
-        if (err) {
-            console.error(err);
-            tmappUI.displayImageError("unexpected");
-            return;
-        }
+            if (err) {
+                console.error(err);
+                tmappUI.displayImageError("unexpected");
+                return;
+            }
 
-        const missingDataDir = response.missingDataDir;
-        const images = response.images || [];
+            const missingDataDir = response.missingDataDir;
+            const images = response.images || [];
 
-        tmappUI.updateImageBrowser(images);
-        _images = images;
+            tmappUI.updateImageBrowser(images);
+            _images = images;
 
-        if (missingDataDir) {
-            tmappUI.displayImageError("missingdatadir");
-        }
-        else if (images.length === 0) {
-            tmappUI.displayImageError("noavailableimages");
-        }
-        else if (imageName && collab) {
-            openImage(imageName, () => {
-                collabClient.connect(collab);
-                if (initialState) moveTo(initialState, true);
-            });
-        }
-        else if (imageName) {
-            openImage(imageName, () => {
-                collabPicker.open(imageName, true, true, () => {
+            if (missingDataDir) {
+                tmappUI.displayImageError("missingdatadir");
+            }
+            else if (images.length === 0) {
+                tmappUI.displayImageError("noavailableimages");
+            }
+            else if (imageName && collab) {
+                openImage(imageName, () => {
+                    collabClient.connect(collab);
                     if (initialState) moveTo(initialState, true);
                 });
-            });
-        }
-        else {
-            tmappUI.displayImageError("noimage");
-            $("#image_browser").modal();
-        }
-    });
-}
+            }
+            else if (imageName) {
+                openImage(imageName, () => {
+                    collabPicker.open(imageName, true, true, () => {
+                        if (initialState) moveTo(initialState, true);
+                    });
+                });
+            }
+            else {
+                tmappUI.displayImageError("noimage");
+                $("#image_browser").modal();
+            }
+        });
+    }
 
     /**
      * Open a specified image in the viewport. If annotations have been

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -676,7 +676,6 @@ function init({ imageName, collab, initialState }) {
         tmappUI.updateImageBrowser(images);
         _images = images;
 
-        // Same logic as before
         if (missingDataDir) {
             tmappUI.displayImageError("missingdatadir");
         }

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -617,6 +617,33 @@ const tmapp = (function() {
         _availableZLevels = null;
     }
 
+function _fetchImages(done) {
+    const req = new XMLHttpRequest();
+    req.open("GET", window.location.api + "/images", true);
+
+    // Avoid cached responses
+    req.setRequestHeader("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0");
+    req.setRequestHeader("Pragma", "no-cache");
+    req.setRequestHeader("Expires", "0");
+
+    req.onreadystatechange = function () {
+        if (req.readyState !== 4) return;
+
+        if (req.status === 200) {
+            try {
+                const response = JSON.parse(req.responseText);
+                done(null, response);
+            } catch (err) {
+                done(err, null);
+            }
+        } else {
+            done(new Error(`HTTP ${req.status}`), null);
+        }
+    };
+
+    req.send(null);
+}
+
     /**
      * Initiate tmapp by fetching a list of images from the server,
      * filling the image browser, and going to the image specified
@@ -633,69 +660,48 @@ const tmapp = (function() {
      * @param {number} options.initialState.z Z level in viewport.
      * @param {number} options.initialState.zoom Zoom in viewport.
      */
-    function init({imageName, collab, initialState}) {
+function init({ imageName, collab, initialState }) {
+    _fetchImages((err, response) => {
+        tmappUI.setUserName(userInfo.getName());
 
-        // Initiate a HTTP request and send it to the image info endpoint
-        const imageReq = new XMLHttpRequest();
-        imageReq.open("GET", window.location.api + "/images", true);
-        // Turn off caching of response
-        imageReq.setRequestHeader("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0"); // HTTP 1.1
-        imageReq.setRequestHeader("Pragma", "no-cache"); // HTTP 1.0
-        imageReq.setRequestHeader("Expires", "0"); // Proxies
-
-        imageReq.send(null);
-
-        imageReq.onreadystatechange = function() {
-            if (imageReq.readyState !== 4) {
-                return;
-            }
-            tmappUI.setUserName(userInfo.getName());
-            switch (imageReq.status) {
-                case 200:
-                    // Add the images to the image browser
-                    const response = JSON.parse(imageReq.responseText);
-                    const missingDataDir = response.missingDataDir;
-                    const images = response.images;
-                    tmappUI.updateImageBrowser(images);
-                    _images = images;
-
-                    // Go to the initial image and/or join the collab
-                    if (missingDataDir) {
-                        tmappUI.displayImageError("missingdatadir");
-                    }
-                    else if (images.length === 0) {
-                        tmappUI.displayImageError("noavailableimages");
-                    }
-                    else if (imageName && collab) {
-                        openImage(imageName, () => {
-                            collabClient.connect(collab);
-                            if (initialState) {
-                                moveTo(initialState, true);
-                            }
-                        });
-                    }
-                    else if (imageName) {
-                        openImage(imageName, () => {
-                            collabPicker.open(imageName, true, true, () => {
-                                if (initialState) {
-                                    moveTo(initialState, true);
-                                }
-                            });
-                        });
-                    }
-                    else {
-                        tmappUI.displayImageError("noimage");
-                        $("#image_browser").modal();
-                    }
-                    break;
-                case 500:
-                    tmappUI.displayImageError("servererror");
-                    break;
-                default:
-                    tmappUI.displayImageError("unexpected");
-            }
+        if (err) {
+            console.error(err);
+            tmappUI.displayImageError("unexpected");
+            return;
         }
-    }
+
+        const missingDataDir = response.missingDataDir;
+        const images = response.images || [];
+
+        tmappUI.updateImageBrowser(images);
+        _images = images;
+
+        // Same logic as before
+        if (missingDataDir) {
+            tmappUI.displayImageError("missingdatadir");
+        }
+        else if (images.length === 0) {
+            tmappUI.displayImageError("noavailableimages");
+        }
+        else if (imageName && collab) {
+            openImage(imageName, () => {
+                collabClient.connect(collab);
+                if (initialState) moveTo(initialState, true);
+            });
+        }
+        else if (imageName) {
+            openImage(imageName, () => {
+                collabPicker.open(imageName, true, true, () => {
+                    if (initialState) moveTo(initialState, true);
+                });
+            });
+        }
+        else {
+            tmappUI.displayImageError("noimage");
+            $("#image_browser").modal();
+        }
+    });
+}
 
     /**
      * Open a specified image in the viewport. If annotations have been
@@ -1032,6 +1038,29 @@ const tmapp = (function() {
             throw new Error ("Tried to adjust scalebar without a viewer.");
         }
     }
+function refreshImageBrowser() {
+
+    _fetchImages((err, response) => {
+
+        if (err) {
+            console.error(err);
+            tmappUI.displayImageError("unexpected");
+            return;
+        }
+
+        const missingDataDir = response.missingDataDir;
+        const images = response.images || [];
+
+        _images = images;
+        tmappUI.clearImageBrowser();
+        tmappUI.updateImageBrowser(images);
+
+        if (missingDataDir) tmappUI.displayImageError("missingdatadir");
+        else if (images.length === 0) tmappUI.displayImageError("noavailableimages");
+        else tmappUI.clearImageError && tmappUI.clearImageError();
+    });
+}
+
 
     return {
         init,
@@ -1069,6 +1098,8 @@ const tmapp = (function() {
         keyDownHandler,
         mouseHandler,
 
-        updateScalebar
+        updateScalebar,
+
+        refreshImageBrowser
     };
 })();

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -324,6 +324,10 @@ const tmappUI = (function(){
         $("#focus_prev").click(tmapp.decrementFocus);
     }
 
+    function _initRefreshImagesButtonEvent() {
+        $("#image_list_refresh").click(tmapp.refreshImageBrowser);
+    }
+
     // Adjust size of rightmost grid column
     function _setLogWidth(width) {
         function handleWidthChange(small) {
@@ -548,6 +552,7 @@ const tmappUI = (function(){
         _initVisualizationSliders();
         _initKeyboardShortcuts();
         _initCollaborationMenu();
+        _initRefreshImagesButtonEvent();
     }
 
     /**
@@ -1012,6 +1017,10 @@ const tmappUI = (function(){
         return _pageInFocus;
     }
 
+    function clearImageBrowser() {
+        $("#available_images").empty();
+    }
+
     return {
         initUI,
         updateClassSelectionButtons,
@@ -1028,6 +1037,7 @@ const tmappUI = (function(){
         clearImageError,
 
         updateImageBrowser,
+        clearImageBrowser,
 
         setUserName,
         setCollabName,

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -1017,6 +1017,9 @@ const tmappUI = (function(){
         return _pageInFocus;
     }
 
+    /**
+     * Clears the images contained inside the image browser.
+     */
     function clearImageBrowser() {
         $("#available_images").empty();
     }


### PR DESCRIPTION
Adds a Refresh button to the image browser to detect newly added/removed images without reloading the page. Also refactor image fetching into `_fetchImages` and reuse it in `init()` to avoid duplicated request code. Fixes #260. 

<img width="1139" height="268" alt="image" src="https://github.com/user-attachments/assets/967835bb-1f66-4f26-a1b9-fedeef8bd56d" />

