### PR TITLE
Devel/fix fast z level change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -588,6 +589,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -999,6 +1001,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",

--- a/public/index.html
+++ b/public/index.html
@@ -828,6 +828,7 @@
 <script src="js/misc/clientVersion.js"></script>
 <script src="js/utils/classUtils.js"></script>
 <script src="js/utils/dateUtils.js"></script>
+<script src="js/utils/timeUtils.js"></script>
 <script src="js/utils/mathUtils.js"></script>
 <script src="js/utils/htmlUtils.js"></script>
 <script src="js/versionRevert.js"></script>

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -418,9 +418,9 @@ const tmapp = (function() {
             moveHandler(event);
         });
         
-        // Add hook to scroll without zooming, didn't seem possible without
+        // Add hook to scroll without zooming
         // Rate limit most scroll actions, to make them more usable with e.g. a touchpad
-        const _rateLimitedScroll=tmappUI.rateLimit((event)=>_scrollHook(event),10);
+        const _rateLimitedScroll=timeUtils.rateLimit((event)=>_scrollHook(event),100,true);
         function scrollHook(event){
             if (event.originalEvent.ctrlKey || event.originalEvent.altKey || event.originalEvent.shiftKey) {
                 event.preventDefaultAction = true; //avoid zooming

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -419,35 +419,36 @@ const tmapp = (function() {
         });
         
         // Add hook to scroll without zooming, didn't seem possible without
-        let timeout = null;
+        // Rate limit most scroll actions, to make them more usable with e.g. a touchpad
+        const _rateLimitedScroll=tmappUI.rateLimit((event)=>_scrollHook(event),10);
         function scrollHook(event){
+            if (event.originalEvent.ctrlKey || event.originalEvent.altKey || event.originalEvent.shiftKey) {
+                event.preventDefaultAction = true; //avoid zooming
+            }
+            _rateLimitedScroll(null,event);
+        }
+        function _scrollHook(event){
             // Ctrl scroll -> Focus change
-            clearTimeout(timeout);
             if (event.originalEvent.ctrlKey) {
-                event.preventDefaultAction = true;
-                timeout = setTimeout(() => {
-                    if (event.scroll > 0) {
-                        incrementFocus();
-                    }
-                    else if (event.scroll < 0) {
-                        decrementFocus();
-                    }
-                },100)
+                if (event.scroll > 0) {
+                    incrementFocus();
+                }
+                else if (event.scroll < 0) {
+                    decrementFocus();
+                }
             }
             // Alt scroll -> MarkerSize change
             if (event.originalEvent.altKey) {
-                event.preventDefaultAction = true;
                 const slider = $('#marker_size_slider');
                 const markerScale = slider.slider('getValue');
                 slider.slider('setValue',markerScale+0.1*Math.sign(event.scroll),true,true);
             }
             // Shift scroll -> Rotate
             if (event.originalEvent.shiftKey) {
-                event.preventDefaultAction = true;
                 const rotation = _currState.targetRotation;
                 _viewer.viewport.setRotation(((rotation + 15*Math.sign(event.scroll)) % 360 + 360) % 360);
             }
-        };
+        }
 
         viewer.addHandler("canvas-scroll", function(event) {
             scrollHook(event);

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -417,18 +417,22 @@ const tmapp = (function() {
             event.position = new OpenSeadragon.Point(event.offsetX,event.offsetY);
             moveHandler(event);
         });
-
+        
         // Add hook to scroll without zooming, didn't seem possible without
+        let timeout = null;
         function scrollHook(event){
             // Ctrl scroll -> Focus change
+            clearTimeout(timeout);
             if (event.originalEvent.ctrlKey) {
                 event.preventDefaultAction = true;
-                if (event.scroll > 0) {
-                    incrementFocus();
-                }
-                else if (event.scroll < 0) {
-                    decrementFocus();
-                }
+                timeout = setTimeout(() => {
+                    if (event.scroll > 0) {
+                        incrementFocus();
+                    }
+                    else if (event.scroll < 0) {
+                        decrementFocus();
+                    }
+                },100)
             }
             // Alt scroll -> MarkerSize change
             if (event.originalEvent.altKey) {

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -8,6 +8,7 @@
  */
 const tmappUI = (function(){
     "use strict";
+    const rateLimit=timeUtils.rateLimit; 
 
     let _pageInFocus = true,
         _errorDisplayTimeout = null;
@@ -844,65 +845,6 @@ const tmappUI = (function(){
         input.removeClass("is-valid");
     }
 
-
-
-    /**
-     * @param {*} fun Function to call after delay in range [0,maxWait]
-     * @param {*} maxWait Default maximume waiting time before triggered, in ms
-     * @returns fun, Function to be executed with rate limitation, always called asynchronously 
-     * fun(newWait[,args]), where newWait=null => maxWait from creation
-     * fun.clearPending() => throw them away
-     * fun.flush() => run pending now!
-     */
-    function rateLimit(fun,maxWait) {
-        let lastRun=0;
-        let pending=0;
-        let argsStore=undefined;
-        function clearPending() {
-            if (pending) {
-                clearTimeout(pending);
-                pending=0;
-            }
-        }
-        function flush() { //run pending now!
-            if (pending) {
-                console.log('Flushrun!');
-                clearPending();
-                runFun();
-            }
-        }            
-        function runFun() {
-            fun(...argsStore);
-            lastRun=Date.now();
-            pending=0;
-        }
-        const retfun=(newWait, ...args) => {
-            argsStore=args;
-            if (newWait == null) {
-                newWait=maxWait; //default wait
-            }
-            clearPending();
-            if (newWait===0) { //immediate
-                runFun();
-            }
-            else { 
-                let delay=Math.max(0,lastRun+newWait-Date.now()); 
-                //console.log(`Delay: ${delay}, MW: ${newWait}, LR:${lastRun}`);
-                console.assert(delay<=newWait);
-                if (delay>0) {
-                    console.assert(!pending);
-                    pending=setTimeout(()=>runFun(),delay);
-                }
-                else {
-                    runFun(); //no task switch
-                }
-            }
-        }
-        retfun.clearPending=clearPending;
-        retfun.flush=flush;
-        return retfun;
-    }
-
     const _scheduleUpdateQR=rateLimit(() => {
         const siz=120;
         $("#qr-code").empty();
@@ -1041,7 +983,6 @@ const tmappUI = (function(){
         clearFilterInfo,
         setURL,
 
-        inFocus,
-        rateLimit
+        inFocus
     };
 })();

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -1041,6 +1041,7 @@ const tmappUI = (function(){
         clearFilterInfo,
         setURL,
 
-        inFocus
+        inFocus,
+        rateLimit
     };
 })();

--- a/public/js/utils/timeUtils.js
+++ b/public/js/utils/timeUtils.js
@@ -1,0 +1,70 @@
+/**
+ * Utility functions for anything with time and timeouts
+ * @namespace timeUtils
+ */
+const timeUtils = (function() {
+    /**
+     * @param {*} fun Function to call after delay in range [0,maxWait]
+     * @param {*} maxWait Default maximume waiting time before triggered, in ms
+     * @param {boolean} [ignoreDelayed=false] Ignore calls which would be delayed
+     * @returns fun, Function to be executed with rate limitation, always called asynchronously 
+     * fun(newWait[,args]), where newWait=null => maxWait from creation
+     * fun.clearPending() => throw them away
+     * fun.flush() => run pending now!
+     */
+    function rateLimit(fun,maxWait,ignoreDelayed=false) {
+        let lastRun=0;
+        let pending=0;
+        let argsStore=undefined;
+        function clearPending() {
+            if (pending) {
+                clearTimeout(pending);
+                pending=0;
+            }
+        }
+        function flush() { //run pending now!
+            if (pending) {
+                console.log('Flushrun!');
+                clearPending();
+                runFun();
+            }
+        }            
+        function runFun() {
+            fun(...argsStore);
+            lastRun=Date.now();
+            pending=0;
+        }
+        const retfun=(newWait, ...args) => {
+            argsStore=args;
+            if (newWait == null) {
+                newWait=maxWait; //default wait
+            }
+            clearPending();
+            if (newWait===0) { //immediate
+                runFun();
+            }
+            else { 
+                let delay=Math.max(0,lastRun+newWait-Date.now()); 
+                //console.log(`Delay: ${delay}, MW: ${newWait}, LR:${lastRun}`);
+                console.assert(delay<=newWait);
+                if (delay>0) {
+                    console.assert(!pending);
+                    if (!ignoreDelayed) { //otherwise just ignore
+                        pending=setTimeout(()=>runFun(),delay);
+                    }
+                }
+                else {
+                    runFun(); //no task switch
+                }
+            }
+        }
+        retfun.clearPending=clearPending;
+        retfun.flush=flush;
+        return retfun;
+    }
+
+
+    return {
+        rateLimit
+    };
+})();


### PR DESCRIPTION
Rate limits scroll events with modifiers ctrl/alt/shift, making them more usable on laptops where scroll events can fire rapidly. 1st event is immediate, following events are ignored if within 100ms.
Fixes issue #308.