### PR TITLE
Devel/toggle annotation z visibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -162,6 +162,10 @@
                             <hr class="m-2">
                             <div class="card-body px-2 px-lg-3 py-1">
                                 <div class="custom-control custom-switch">
+                                    <input type="checkbox" class="custom-control-input" id="annotations_z_switch">
+                                    <label class="custom-control-label px-1" for="annotations_z_switch">Show annotations across z-levels</label>
+                                </div>
+                                <div class="custom-control custom-switch">
                                     <input type="checkbox" class="custom-control-input" id="fps_switch">
                                     <label class="custom-control-label px-1" for="fps_switch">Show FPS counter</label>
                                 </div>

--- a/public/js/MarkerLayer.js
+++ b/public/js/MarkerLayer.js
@@ -505,9 +505,9 @@ class MarkerLayer extends OverlayLayer {
     }
 
     #exitMarker(exit) {
-        const duration=Math.round(30/(1+exit.size())); //The more markers the shorter animation
+        const duration=Math.round(100/(1+exit.size())); //The more markers the shorter animation
         return exit.each(d => {
-            // console.log('EID:',d.id);
+            // console.log('EID:',d.id,duration);
             const marker = this.#markerList[d.id]
             if (!marker) {
                 console.log(`EXIT: Marker #${d.id} lost before exit, probably from clearAnnotation.`);

--- a/public/js/MarkerLayer.js
+++ b/public/js/MarkerLayer.js
@@ -84,7 +84,7 @@ class MarkerLayer extends OverlayLayer {
         });
 
         pixiOverlay._app.ticker.add(() => {
-            this.#cullMarkers();
+            this.#cullMarkers(undefined,!this.#zVisibility);
         });
     }
 
@@ -154,25 +154,29 @@ class MarkerLayer extends OverlayLayer {
     /**
      * Set marker visible if inside rectangle, or pressed
      * @param {Rectangle} rect in Screen/Web coordinates, typically this.#renderer.screen
+     * @param {bool} cull_z if to only show current z-level
      */
     #first=true;
     #oldUl={};
     #oldDr={};
-    #cullMarkers(rect = this.#renderer.screen) {
+    #oldZ=null;
+    #cullMarkers(rect = this.#renderer.screen, cull_z = false) {
         if (this.#markerContainer.children.length) {
             //Check if the view actually changed
             const ul=coordinateHelper.overlayToWeb({x:0,y:0});
             const dr=coordinateHelper.overlayToWeb({x:1000,y:1000});
+            const z=cull_z?tmapp.getFocusLevel():null;
             ul.x = Math.round(ul.x);
             ul.y = Math.round(ul.y);
             dr.x = Math.round(dr.x);
             dr.y = Math.round(dr.y);
-            if (this.#first || ul.x!=this.#oldUl.x || ul.y!=this.#oldUl.y || dr.x!=this.#oldDr.x || dr.y!=this.#oldDr.y) {
+            if (this.#first || ul.x!=this.#oldUl.x || ul.y!=this.#oldUl.y || dr.x!=this.#oldDr.x || dr.y!=this.#oldDr.y || this.#oldZ!=z) {
                 this.#first=false;
                 this.#oldUl.x = ul.x;
                 this.#oldUl.y = ul.y;
                 this.#oldDr.x = dr.x;
                 this.#oldDr.y = dr.y;
+                this.#oldZ = z;
                 rect=rect.clone().pad(this.#markerDiameter/2); //So we see frame also when outside
 
                 const topLeft = coordinateHelper.webToImage({ x: rect.x, y: rect.y });
@@ -187,12 +191,15 @@ class MarkerLayer extends OverlayLayer {
                     minX: Math.min(...xs),
                     minY: Math.min(...ys),
                     maxX: Math.max(...xs),
-                    maxY: Math.max(...ys)
+                    maxY: Math.max(...ys),
+                    z: tmapp.getFocusLevel()
                 };
                 const visibleMarkers = this.#spatialMarkerIndex.search(bbox);
                 const visibleIDs = new Set();
                 for (const m of visibleMarkers) {
-                    visibleIDs.add(m.id);
+                    if (!cull_z || m.z==bbox.z) {
+                        visibleIDs.add(m.id);
+                    }
                 }
 
                 let vis = 0;
@@ -379,6 +386,7 @@ class MarkerLayer extends OverlayLayer {
         sprite.id = d.id;
         sprite.mclass = d.mclass;
         sprite.hitArea = texture.hitArea;
+        sprite.z = d.z;
 
         this.#addMarkerInteraction(d, sprite, sprite);
         this.#markerContainer.addChild(sprite);
@@ -429,6 +437,7 @@ class MarkerLayer extends OverlayLayer {
                     minY: y,
                     maxX: x,
                     maxY: y,
+                    z: d.z,
                     id: d.id,
                 };
                 this.#spatialMarkerIndex.insert(markerItem);
@@ -487,6 +496,7 @@ class MarkerLayer extends OverlayLayer {
     }
 
     #exitMarker(exit) {
+        const duration=Math.round(30/(1+exit.size())); //The more markers the shorter animation
         return exit.each(d => {
             // console.log('EID:',d.id);
             const marker = this.#markerList[d.id]
@@ -497,10 +507,15 @@ class MarkerLayer extends OverlayLayer {
             Ease.ease.removeEase(marker);
             marker.interactive = false;
             if (!marker.destroyed) {
-                Ease.ease.add(marker,{scale:marker.scale.x*1.5},{duration:30})
-                    .once('complete', (ease) => {
-                        ease.elements.forEach(item=>item.destroy({children: true, texture: false})); //Self destruct after animation
-                    });
+                if (duration > 0) {
+                    Ease.ease.add(marker,{scale:marker.scale.x*1.5},{duration:duration})
+                        .once('complete', (ease) => {
+                            ease.elements.forEach(item=>item.destroy({children: true, texture: false})); //Self destruct after animation
+                        });
+                }
+                else {
+                    marker.destroy({children: true, texture: false});
+                }
             }
             delete this.#markerList[d.id];
             const existingMarker = this.#annotationIdToMarker.get(d.id);
@@ -561,10 +576,9 @@ class MarkerLayer extends OverlayLayer {
         }
         //Draw annotations and update list asynchronously
         this.updateAnnotations.inProgress(true); //No function 'self' existing
-        const markers = annotations.filter(annotation => (
-                annotation.points.length === 1 && 
-                (this.#zVisibility || annotation.z === tmapp.getFocusLevel())
-        ));
+        const markers = annotations.filter(annotation =>
+            annotation.points.length === 1
+        );
         this.#markerOverlay.selectAll("g")
             .data(markers, d => d.id)
             .join(

--- a/public/js/MarkerLayer.js
+++ b/public/js/MarkerLayer.js
@@ -18,7 +18,7 @@ class MarkerLayer extends OverlayLayer {
     #maxScale;
     #markerScale = 1; //Modifcation factor
     #markerTextures = null;
-    #zVisibility = false;
+    #zVisibility = true;
 
     #overlayObject = null; //For destroy
     #stage = null; //Pixi stage

--- a/public/js/MarkerLayer.js
+++ b/public/js/MarkerLayer.js
@@ -18,6 +18,7 @@ class MarkerLayer extends OverlayLayer {
     #maxScale;
     #markerScale = 1; //Modifcation factor
     #markerTextures = null;
+    #zVisibility = false;
 
     #overlayObject = null; //For destroy
     #stage = null; //Pixi stage
@@ -560,9 +561,10 @@ class MarkerLayer extends OverlayLayer {
         }
         //Draw annotations and update list asynchronously
         this.updateAnnotations.inProgress(true); //No function 'self' existing
-        const markers = annotations.filter(annotation =>
-            annotation.points.length === 1
-        );
+        const markers = annotations.filter(annotation => (
+                annotation.points.length === 1 && 
+                (this.#zVisibility || annotation.z === tmapp.getFocusLevel())
+        ));
         this.#markerOverlay.selectAll("g")
             .data(markers, d => d.id)
             .join(
@@ -610,6 +612,9 @@ class MarkerLayer extends OverlayLayer {
     }
 
 
+    setAnnotationZVisibility(visible) {
+        this.#zVisibility = visible;
+    }
 
     #alpha(obj,s) {
         Ease.ease.add(obj,{alpha:s},{duration:200});

--- a/public/js/MarkerLayer.js
+++ b/public/js/MarkerLayer.js
@@ -466,6 +466,7 @@ class MarkerLayer extends OverlayLayer {
                     minY: y,
                     maxX: x,
                     maxY: y,
+                    z: d.z,
                     id: d.id,
                 };
                 this.#spatialMarkerIndex.insert(markerItem);

--- a/public/js/MarkerLayer.js
+++ b/public/js/MarkerLayer.js
@@ -27,7 +27,7 @@ class MarkerLayer extends OverlayLayer {
     #drawUpdate = null; //Rendring update function
 
     #spatialMarkerIndex = new RBush();
-    #annotationIdToMarker = new Map();
+    #annotationIdToMarker = new Map(); //isn't this just partly duplicating markerList? (JL 260815)
     
     #markerOverlay;
     #markerContainer = null;
@@ -83,7 +83,7 @@ class MarkerLayer extends OverlayLayer {
             }
         });
 
-        pixiOverlay._app.ticker.add(() => {
+        pixiOverlay._app.ticker.add(() => { // cull during spare time
             this.#cullMarkers(undefined,!this.#zVisibility);
         });
     }
@@ -160,23 +160,23 @@ class MarkerLayer extends OverlayLayer {
     #oldUl={};
     #oldDr={};
     #oldZ=null;
+    #visibleMarkers2D=null; //in the 2D bbox 
     #cullMarkers(rect = this.#renderer.screen, cull_z = false) {
         if (this.#markerContainer.children.length) {
-            //Check if the view actually changed
+            //Check if the view changed
+            let change2D=false;
             const ul=coordinateHelper.overlayToWeb({x:0,y:0});
             const dr=coordinateHelper.overlayToWeb({x:1000,y:1000});
-            const z=cull_z?tmapp.getFocusLevel():null;
             ul.x = Math.round(ul.x);
             ul.y = Math.round(ul.y);
             dr.x = Math.round(dr.x);
             dr.y = Math.round(dr.y);
-            if (this.#first || ul.x!=this.#oldUl.x || ul.y!=this.#oldUl.y || dr.x!=this.#oldDr.x || dr.y!=this.#oldDr.y || this.#oldZ!=z) {
+            if (this.#first || ul.x!=this.#oldUl.x || ul.y!=this.#oldUl.y || dr.x!=this.#oldDr.x || dr.y!=this.#oldDr.y) {
                 this.#first=false;
                 this.#oldUl.x = ul.x;
                 this.#oldUl.y = ul.y;
                 this.#oldDr.x = dr.x;
                 this.#oldDr.y = dr.y;
-                this.#oldZ = z;
                 rect=rect.clone().pad(this.#markerDiameter/2); //So we see frame also when outside
 
                 const topLeft = coordinateHelper.webToImage({ x: rect.x, y: rect.y });
@@ -192,12 +192,16 @@ class MarkerLayer extends OverlayLayer {
                     minY: Math.min(...ys),
                     maxX: Math.max(...xs),
                     maxY: Math.max(...ys),
-                    z: tmapp.getFocusLevel()
                 };
-                const visibleMarkers = this.#spatialMarkerIndex.search(bbox);
+                this.#visibleMarkers2D = this.#spatialMarkerIndex.search(bbox); //array
+                change2D=true;
+            }
+            const z=cull_z?tmapp.getFocusLevel():null;
+            if (change2D || this.#oldZ!=z) { //if 2D-change or z-change
+                this.#oldZ = z;
                 const visibleIDs = new Set();
-                for (const m of visibleMarkers) {
-                    if (!cull_z || m.z==bbox.z) {
+                for (const m of this.#visibleMarkers2D) {
+                    if (!cull_z || this.#markerList[m.id].z===z) {
                         visibleIDs.add(m.id);
                     }
                 }
@@ -218,8 +222,7 @@ class MarkerLayer extends OverlayLayer {
             }
         }
     }
-
-    
+   
     #resizeMarkers() {
 //        console.log('Resize: ',this.#markerSize);
         this.#markerContainer.children.forEach(c => {
@@ -428,6 +431,7 @@ class MarkerLayer extends OverlayLayer {
             .each(d => {
                 // console.log('AID: ',d.id,duration);
                 this.#markerList[d.id]=this.#pixiMarker(d,duration);
+                this.#setMarkerZVisibility(this.#markerList[d.id]); //if added outside visibleZ
 
                 // Add marker to spatial index and ID map
                 const x = d.points[0].x;
@@ -437,7 +441,6 @@ class MarkerLayer extends OverlayLayer {
                     minY: y,
                     maxX: x,
                     maxY: y,
-                    z: d.z,
                     id: d.id,
                 };
                 this.#spatialMarkerIndex.insert(markerItem);
@@ -466,11 +469,16 @@ class MarkerLayer extends OverlayLayer {
                     minY: y,
                     maxX: x,
                     maxY: y,
-                    z: d.z,
                     id: d.id,
                 };
                 this.#spatialMarkerIndex.insert(markerItem);
                 this.#annotationIdToMarker.set(d.id, markerItem);
+            }
+
+            if (marker.z!==d.z) { 
+                marker.z=d.z;
+                this.#setMarkerZVisibility(this.#markerList[d.id]);
+                changed = true;
             }
             
             if (marker.mclass!==d.mclass) {
@@ -525,6 +533,11 @@ class MarkerLayer extends OverlayLayer {
         }).remove();
     }
 
+    #setMarkerZVisibility(marker) {
+        const vis=(marker.pressed || this.#zVisibility || marker.z==tmapp.getFocusLevel());
+        marker.visible = vis;
+        marker.interactive = vis;
+    }
 
     /**
      * Clear all annotations currently in the overlay, in case you need to quickly replace them.

--- a/public/js/RegionLayer.js
+++ b/public/js/RegionLayer.js
@@ -6,6 +6,7 @@
 class RegionLayer extends OverlayLayer {
     #timingLog = false; //Log update times
     #scale = 1;
+    #zVisibility = false;
 
     #regionOverlay;
     #pendingRegionOverlay;
@@ -348,9 +349,10 @@ class RegionLayer extends OverlayLayer {
 
         //Draw annotations and update list asynchronously
         this.updateAnnotations.inProgress(true); //No function 'self' existing
-        const regions = annotations.filter(annotation =>
-            annotation.points.length > 1
-        );
+        const regions = annotations.filter(annotation => (
+            annotation.points.length > 1 && 
+            (this.#zVisibility || annotation.z === tmapp.getFocusLevel())
+        ));
 
         const doneRegions = new Promise((resolve, reject) => {
             const regs = this.#regionOverlay.selectAll(".region")
@@ -465,6 +467,9 @@ class RegionLayer extends OverlayLayer {
     }
 
 
+    setAnnotationZVisibility(visible) {
+        this.#zVisibility = visible;
+    }
 
     /**
      * Called when layer is lowered away from top

--- a/public/js/RegionLayer.js
+++ b/public/js/RegionLayer.js
@@ -6,7 +6,7 @@
 class RegionLayer extends OverlayLayer {
     #timingLog = false; //Log update times
     #scale = 1;
-    #zVisibility = false;
+    #zVisibility = true;
 
     #regionOverlay;
     #pendingRegionOverlay;

--- a/public/js/RegionLayer.js
+++ b/public/js/RegionLayer.js
@@ -313,7 +313,8 @@ class RegionLayer extends OverlayLayer {
     }
 
     #exitRegion(exit) {
-        return exit.transition("appear").duration(200)
+        return exit.transition("appear")
+            .duration(d => (this.#zVisibility || d.z === tmapp.getFocusLevel()) ? 200 : 0)
             .attr("opacity", 0)
             .remove();
     }

--- a/public/js/RegionLayer.js
+++ b/public/js/RegionLayer.js
@@ -312,11 +312,14 @@ class RegionLayer extends OverlayLayer {
             );
     }
 
-    #exitRegion(exit) {
-        return exit.transition("appear")
-            .duration(d => (this.#zVisibility || d.z === tmapp.getFocusLevel()) ? 200 : 0)
+    #exitRegion(exit) { //exit return value ignored in d3.join(...)
+        const animate = this.#zVisibility? exit: exit.filter(d=>d.z===tmapp.getFocusLevel());
+        const direct = this.#zVisibility? d3.select(null): exit.filter(d=>d.z!==tmapp.getFocusLevel());
+        animate.transition("appear")
+            .duration(200)
             .attr("opacity", 0)
             .remove();
+        direct.remove(); // Immediate remove required to avoid missing regions on quick back&forth z-changes
     }
 
 

--- a/public/js/annotationHandler.js
+++ b/public/js/annotationHandler.js
@@ -181,7 +181,7 @@ const annotationHandler = (function (){
         );
     }
 
-    function _updateVisuals() {
+    function updateVisuals() {
         annotationVisuals.update(Array.from(_annotationMap.values()));
     }
 
@@ -342,7 +342,7 @@ const annotationHandler = (function (){
         timingLog && console.timeEnd('addAnnotation');
 
         // Add a graphical representation of the annotation
-        _updateVisuals();
+        updateVisuals();
     }
 
     /**
@@ -438,7 +438,7 @@ const annotationHandler = (function (){
 
 
         // Update the annotation in the graphics
-        redraw && _updateVisuals();
+        redraw && updateVisuals();
         timingLog && console.timeEnd('updateAnnotation update()');
     }
 
@@ -507,7 +507,7 @@ const annotationHandler = (function (){
         updateAnnotationCounts();
 
         // Remove the annotation from the graphics
-        _updateVisuals();
+        updateVisuals();
     }
 
     /**
@@ -582,6 +582,7 @@ const annotationHandler = (function (){
 
     // Return public members of the closure
     return {
+        updateVisuals,
         add,
         update,
         setBookmarked,

--- a/public/js/layerHandler.js
+++ b/public/js/layerHandler.js
@@ -15,7 +15,8 @@ const layerHandler = (function (){
         _wContainer,
         _maxZoom,
         _rotation,
-        _markerScale = 1; //Modifcation factor
+        _markerScale = 1, //Modifcation factor
+        _markerZVisibility = false;
 
 
     function _forEachLayer(funStr, ...args) {
@@ -75,6 +76,15 @@ const layerHandler = (function (){
     function setMarkerScale(markerScale, delta=false) {
         _markerScale = markerScale;
         _forEachLayer("setMarkerScale",_markerScale, delta);
+    }
+
+    /**
+     * Adjust annotation visibility across z-levels. 
+     * @param {boolean} visible Whether annotations should be visible across z-levels. 
+     */
+    function setAnnotationZVisibility(visible) {
+        _markerZVisibility = visible;
+        _forEachLayer("setAnnotationZVisibility", visible);
     }
 
     /**
@@ -173,6 +183,7 @@ const layerHandler = (function (){
         destroy,
         setZoom,
         setMarkerScale,
+        setAnnotationZVisibility,
         setRotation,
         setActiveAnnotationOverlay:setTopLayer,
         getActiveAnnotationOverlay:getTopLayer,

--- a/public/js/layerHandler.js
+++ b/public/js/layerHandler.js
@@ -16,7 +16,7 @@ const layerHandler = (function (){
         _maxZoom,
         _rotation,
         _markerScale = 1, //Modifcation factor
-        _markerZVisibility = false;
+        _markerZVisibility = true;
 
 
     function _forEachLayer(funStr, ...args) {

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -64,7 +64,7 @@ const tmapp = (function() {
         },
         _disabledControls=false, //showing controls and navigator
         _availableZLevels, //how is this different from _currentImage.zLevels?
-        _annotationZVisibility=false,
+        _annotationZVisibility=true,
         _mouseHandler,
         _currentMouseUpdateFun=null;
 

--- a/public/js/tmapp.js
+++ b/public/js/tmapp.js
@@ -64,6 +64,7 @@ const tmapp = (function() {
         },
         _disabledControls=false, //showing controls and navigator
         _availableZLevels, //how is this different from _currentImage.zLevels?
+        _annotationZVisibility=false,
         _mouseHandler,
         _currentMouseUpdateFun=null;
 
@@ -75,12 +76,20 @@ const tmapp = (function() {
         z = Math.min(Math.max(z,-ofs),count-1-ofs);
         setFocusIndex(z+ofs);
     }
+    function getFocusLevel() {
+        return _currState.z;
+    }
     function getFocusIndex() {
         return  _viewer.getFocusIndex(); //From the focus-levels plugin
     }
     function setFocusIndex(z0) {
         _viewer.setFocusIndex(z0);
         _updateFocus();
+    }
+
+    function setAnnotationZVisibility(visible) {
+        _annotationZVisibility = visible;
+        layerHandler.setAnnotationZVisibility(visible);
     }
 
     function _updateFocus() {
@@ -94,6 +103,8 @@ const tmapp = (function() {
         htmlHelper.updateFocusSlider(_viewer,index); 
         tmappUI.setImageZLevel(_currentImage.zLevels[index]); //Write in UI
         coordinateHelper.setImage(_viewer.world.getItemAt(index)); 
+        // If annotation z limit is active
+        if (!_annotationZVisibility) {annotationHandler.updateVisuals()};
         _updateCollabPosition();
         _updateURLParams();
     }
@@ -1136,6 +1147,8 @@ function _fetchImages(callback) {
         getZLevels,
         setFocusIndex,
         getFocusIndex,
+        getFocusLevel,
+        setAnnotationZVisibility,
 
         setBrightness,
         setContrast,

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -356,6 +356,12 @@ const tmappUI = (function(){
         $("#brightness_reset").click(function() { $('#brightness_slider').slider('setValue', 0, true, true);});
         $("#contrast_reset").click(function() { $('#contrast_slider').slider('setValue', 0, true, true);});
 
+        $("#annotations_z_switch").prop('checked',false); // force it to false, since some browsers cache it incorrectly
+        $("#annotations_z_switch").change(function(e) {
+            tmapp.setAnnotationZVisibility(e.target.checked);
+            annotationHandler.updateVisuals();
+        }); 
+
         $("#fps_switch").prop('checked',false); // force it to false, since some browsers cache it incorrectly
         $("#fps_switch").change(function(e) {
             if (e.target.checked) {

--- a/public/js/tmappUI.js
+++ b/public/js/tmappUI.js
@@ -356,7 +356,7 @@ const tmappUI = (function(){
         $("#brightness_reset").click(function() { $('#brightness_slider').slider('setValue', 0, true, true);});
         $("#contrast_reset").click(function() { $('#contrast_slider').slider('setValue', 0, true, true);});
 
-        $("#annotations_z_switch").prop('checked',false); // force it to false, since some browsers cache it incorrectly
+        $("#annotations_z_switch").prop('checked',true); // force it to false, since some browsers cache it incorrectly
         $("#annotations_z_switch").change(function(e) {
             tmapp.setAnnotationZVisibility(e.target.checked);
             annotationHandler.updateVisuals();


### PR DESCRIPTION
Switch whether annotations should be visible in all or only current z-layer.
Relying on same code as cullMarkers() makes it smooth for 100k markers.
